### PR TITLE
Correct href to point to the home page. Update the app name.

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -90,11 +90,6 @@
         <link href="src/lib/bootstrap/core/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
         <link href="src/style-editor.css" rel="stylesheet" type="text/css" />
         <link href="src/style-clientdownload.css" rel="stylesheet" type="text/css" />
-
-        
-        
-        
-        
     </head>
     
     <body>
@@ -105,7 +100,7 @@
                         <nav class="navbar navbar-default clearfix">
                             <div style="width:100%;">
                                 <div style="display:inline;">
-                                    <a id="nav-logo" href="" class="url-prefix">BlocklyProp<br><strong>Developer</strong></a>
+                                    <a id="nav-logo" href="index.html" class="url-prefix">BlocklyProp<br><strong>Solo</strong></a>
                                 </div>
                                 <div style="display:inline;">
                                     <div style="width:100%;">


### PR DESCRIPTION
Reference Issue #9 
The href for the anchor tag associated with the logo in the upper left corner of the project editor page was empty. This update changes the empty URI to 'index.html', the project home page.

Although not required, it might be a good idea to change this in the future to an onClick event so the app has a chance to evaluate the project state - i.e. unsaved changes - before returning to the home page.

This update also correct the application name displayed on the page header.