### PR TITLE
Solo 16 remove download option from menu

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -160,7 +160,7 @@
                                                     <li><a href="public/help" target="_blank" class="url-prefix"><span class="keyed-lang-string" data-key="menu_help_reference"></span></a></li>
                                                     <li class="divider"></li>
                                                     <li><a id="download-side" href="#"><span class="keyed-lang-string" data-key="menu_download_simpleide"></span></a></li>
-                                                    <li><a id="download-project" href="#"><span class="keyed-lang-string" data-key="editor_download"></span></a></li>
+                                                    <li class="online-only divider" data-displayas="list-item"><a id="download-project" href="#"><span class="keyed-lang-string" data-key="editor_download"></span></a></li>
                                                     <li class="auth-true" data-displayas="list-item"><a id="upload-project"><span class="keyed-lang-string" data-key="editor_upload"></span></a></li>
                                                     <li class="auth-true divider" data-displayas="list-item"></li>
                                                     <li class="auth-true" data-displayas="list-item"><a id="client-setup"><span class="keyed-lang-string" data-key="editor_run_configure"></span></a></li>


### PR DESCRIPTION
Removes "Download blocks file" option in editor menu by making it an online-only option.  Because saving a project in the offline application is the same ad downloading it, the option is redundant and unnecessary.

A corresponding change will be made to blocklyc.jsp to keep it aligned with this project.