### PR TITLE
Issue 35 editor page update breakages

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -104,7 +104,7 @@
     <div id="editor" style="background-color:#f8f8f8; padding-top:0px; padding-bottom:5px;">
 
         <div id="branding" style="position: relative; top: 2px;">
-            <a id="nav-logo" href="" class="url-prefix">
+            <a id="nav-logo" href="/" class="url-prefix">
                 <!-- Branding logo -->
                 <!--# include file="/inc_logo.html" -->
             </a>

--- a/blocklyc.html
+++ b/blocklyc.html
@@ -271,7 +271,7 @@
                 </div>
                 <div class="modal-body">
                     <label class="control-label keyed-lang-string" data-key="editor_upload_selectfile"></label>
-                    <input id="selectfile" type="file" onchange="uploadHandler(this.files);">
+                    <input id="selectfile" type="file" accept=".svg,image/svg+xml" onchange="uploadHandler(this.files);">
                     <div id="selectfile-verify-valid" class="alert alert-success" style="display: none;">
                         <span class="bpIcon" data-icon="checkMarkGreen">&#x2713;</span>&nbsp;
                         <span class="keyed-lang-string" data-key="editor_upload_valid"></span>

--- a/inc_logo.html
+++ b/inc_logo.html
@@ -1,1 +1,1 @@
-BlocklyProp
+BlocklyProp<br><strong>Solo</strong>

--- a/inc_splash.html
+++ b/inc_splash.html
@@ -1,3 +1,3 @@
 <div class="logo">
-    <h2 id="BlocklyProp">BlocklyProp Local</h2>
+    <h2 id="BlocklyProp">BlocklyProp Solo</h2>
 </div>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     <body>
         <nav class="navbar navbar-default">
             <div class="container">
-                <div class="navbar-header">
+                <div id="nav-logo" class="navbar-header">
                     <!-- Branding logo -->
                     <!--# include file="/inc_logo.html" -->
                 </div>

--- a/page_footer.html
+++ b/page_footer.html
@@ -1,25 +1,3 @@
-<!--
-  TERMS OF USE: MIT License
-
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-   to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-  DEALINGS IN THE SOFTWARE.
--->
-
 <!-- Page footer -->
 <footer class="footer">
     <nav class="navbar">
@@ -37,7 +15,7 @@
                 <ul class="nav navbar-nav navbar-right">
                     <li>
                         <a href="http://www.parallax.com" 
-                           target="_blank">V1.3.461 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
+                           target="_blank">V1.3.462 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
                     </li>
                 </ul>
             </div>

--- a/page_footer.html
+++ b/page_footer.html
@@ -15,7 +15,7 @@
                 <ul class="nav navbar-nav navbar-right">
                     <li>
                         <a href="http://www.parallax.com" 
-                           target="_blank">V1.3.462 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
+                           target="_blank">V1.3.463 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Addresses new issues in #35 - Update editor page layout.

Restore the background image in the upper left corner of the home page.
Applies brute-force branding for Solo until a better branding method can be developed.
Restores filter in Open Project dialog to allow selection of only svg files.
