### PR TITLE
Hard-code the page title. This is a temporary patch.

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -50,7 +50,7 @@
     <link type="image/png" rel="icon" sizes="32x32" href="src/images/favicon-32x32.png" />
     <link type="image/png" rel="icon" sizes="16x16" href="src/images/favicon-16x16.png" />
 
-    <title>BlocklyProp</title>
+    <title>BlocklyProp Solo</title>
 
     <!-- JavaScript libraries -->
     <script type="text/javascript" src="src/lib/chartist.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <link rel="stylesheet" href="src/lib/bootstrap/core/css/bootstrap.min.css"/>
         <link rel="stylesheet" href="src/lib/bootstrap/plugins/bootstrap-table.min.css"/>
 
-        <title>BlocklyProp Local</title>
+        <title>BlocklyProp Solo</title>
 
         <script type="application/javascript" src="src/lib/jquery-1.11.3.min.js"></script>
         <script type="application/javascript" src="src/lib/bootstrap/core/js/bootstrap.min.js"></script>


### PR DESCRIPTION
The browser tab displays "BlocklyProp Local". This patch changes the default to "BlocklyProp Solo" until a better solution appears.