### PR TITLE
Solo 34 disable prop c editor

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -29,7 +29,7 @@
     <meta name="projectlink" content="">
     <meta name="isOffline" content="true">
     <meta name="user-auth" content="true">
-    <meta name="in-demo" content="true">
+    <!--<meta name="in-demo" content="true">-->
     <meta name="docker" content="true">
 
     <meta name="application-name" content="BlocklyProp" />


### PR DESCRIPTION
Turns off the "inDemo" fuse, which will disable prop c editing and any blocks or features tagged "experimental".

Addresses #34 