### PR TITLE
Add modal window to display license.

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,48 @@
                 <p><strong>Blockly for Propeller Multicore:</strong>&nbsp;Making amazing projects and learning to code just became easier</p>
                 <p><img class="cdn full-width" style="border: 0" src="src/images/home-banner.png" alt="Home page banner image"></p>
             </div>
+
+            <!-- license -->
+            <div class="container-fluid">
+                <!-- License modal window -->
+                <div class="modal fade" id="licenseModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel"
+                     aria-hidden="true">
+
+                    <!-- Change class .modal-sm to change the size of the modal -->
+                    <div class="modal-dialog modal-lg" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h4 class="modal-title w-100" id="licenseLabel">BlocklyProp Solo License</h4>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <p>The MIT License (MIT)</p>
+                                <p>Copyright © <span id="year"></span> Parallax Inc.</p>
+                                <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+                                    associated documentation files (the “Software”), to deal in the Software without restriction,
+                                    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+                                    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+                                    subject to the following conditions:</p>
+                                <p>The above copyright notice and this permission notice shall be included in all copies or substantial
+                                    portions of the Software.</p>
+                                <p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+                                    LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+                                    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+                                    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,OUT OF OR IN CONNECTION WITH THE
+                                    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+                                <p><script>document.getElementById("year").innerHTML = new Date().getFullYear();</script></p>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-primary btn-sm" data-dismiss="modal">Close</button>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- end of license window -->
+            </div>
         </div>
+
 
         <!--# include file="/page_footer.html" -->
 

--- a/page_footer.html
+++ b/page_footer.html
@@ -5,7 +5,7 @@
             <div>
                 <ul class="nav navbar-nav">
                     <li>
-                        <a href="http://blockly.parallax.com/blockly/public/license">License</a>
+                        <a onclick="showLicense()">License</a>
                     </li>
                     <li>
                         <a href="http://blockly.parallax.com/blockly/public/clientdownload">BlocklyProp Client Downloads</a>
@@ -29,4 +29,9 @@
         let d = new Date();
         document.getElementById("footer_copyright").innerHTML = d.getFullYear().toString();
     });
+
+    // Display the BlocklyProp Solo license in a modal window
+    function showLicense() {
+        $('#licenseModal').modal();
+    }
 </script>


### PR DESCRIPTION
This addresses parallaxinc/solo#41.

The current license link connects the user to the license page on the blockly.parallax.com site. The then requires the user to know that they must select the 'Back' button in order to return to the Solo site. 

This update places the license text in a modal dialog window, where the user can read and then dismiss the license text.
