### PR TITLE
Correct URL for hamburger-help option

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -216,7 +216,7 @@
                         <li class="online-only"><a href="projects.jsp" class="url-prefix"><span
                                     class="keyed-lang-string" data-key="menu_community_projects"></span></a></li>
                         <li class="online-only divider"></li>
-                        <li><a href="public/help" target="_blank" class="url-prefix"><span class="keyed-lang-string"
+                        <li><a href="https://learn.parallax.com/ab-blocks" target="_blank" class="url-prefix"><span class="keyed-lang-string"
                                     data-key="menu_help_reference"></span></a></li>
                         <li class="divider"></li>
                         <li><a id="download-side" href="#"><span class="keyed-lang-string"


### PR DESCRIPTION
Addresses issue #48 
Replace the target URL in the HTML code to point to the online help available at the Learn site.