### PR TITLE
Updates to BlocklyProp Client downloads

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -32,7 +32,9 @@
 
     <!-- BlockyProp Client download links -->
     <meta name="win32client" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-32.exe">
+    <meta name="win32zipclient" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-32.zip">
     <meta name="win64client" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-64.exe">
+    <meta name="win64zipclient" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-64.zip">
     <meta name="macOSclient" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-MacOS.pkg">
 
 
@@ -829,6 +831,16 @@
                             </a>
                         </div>
 
+                        <!-- Windows x32 client zip file -->
+                        <div class="client Windows">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                                 data-src="images/os-icons/windows.png" alt="Windows OS icon" />
+                            <a href="#" class="client-win32zip-link">
+                                <span class="keyed-lang-string"
+                                      data-key="clientdownload_client_windows32zip_installer"></span>
+                            </a>
+                        </div>
+
                         <!-- Windows x64 client -->
                         <div class="client Windows">
                             <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -836,6 +848,17 @@
                             <a href="#" class="client-win64-link">
                                 <span class="keyed-lang-string"
                                     data-key="clientdownload_client_windows64_installer"></span>
+                            </a>
+                        </div>
+
+
+                        <!-- Windows x64 client -->
+                        <div class="client Windows">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                                 data-src="images/os-icons/windows.png" alt="Windows OS icon" />
+                            <a href="#" class="client-win64zip-link">
+                                <span class="keyed-lang-string"
+                                      data-key="clientdownload_client_windows64zip_installer"></span>
                             </a>
                         </div>
 


### PR DESCRIPTION
Addresses issues Solo #54 and Solo #66 

Added missing <meta> tags that provided the URL to the specific client download files.
Add download option for Windows client in a zip file because some firewalls may not allow a .exe file to pass through.

There is a matching pull request in parallaxinc/blocklyprop-cdn#211 that provides updates for the text in the update presented here.