### PR TITLE
Make project name editable

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -114,206 +114,208 @@
         <div id="branding" style="position: relative; top: 2px;">
             <a id="nav-logo" href="/" class="url-prefix"></a>
         </div>
-
-        <!-- Above toolbar -->
         <div>
-            <!-- BlocklyProp Client or Loader UI -->
-            <div id="client-status-alerts" style="display: inline;">
-                <span class="auth-true" style="padding-left: 10px; line-height: 30px;">
-                    <span id="client-searching" class="bp-client-warning">
-                        <a class="client-searching-link" data-toggle="modal" data-target="#client-download-modal"
-                            href="#">
-                            <span class="bpIcon" data-icon="warningCircle">!</span>
-                            <span class="keyed-lang-string" data-key="editor_client_checking"></span>
+            <!-- Above toolbar -->
+            <div style="overflow:auto;">
+
+                <!-- BlocklyProp Client or Loader UI -->
+                <div id="client-status-alerts" style="float: left;">
+                    <span class="auth-true" style="padding-left: 10px; line-height: 30px;">
+                        <span id="client-searching" class="bp-client-warning">
+                            <a class="client-searching-link" data-toggle="modal" data-target="#client-download-modal"
+                                href="#">
+                                <span class="bpIcon" data-icon="warningCircle">!</span>
+                                <span class="keyed-lang-string" data-key="editor_client_checking"></span>
+                            </a>
+                        </span>
+                        <span id="client-unavailable" class="bp-client-danger hidden">
+                            <a class="client-unavailable-link" data-toggle="modal" data-target="#client-download-modal"
+                                href="#">
+                                <span class="bpIcon" data-icon="dangerTriangle">!!</span>
+                                <span class="keyed-lang-string" data-key="editor_client_not-available"></span>
+                            </a>
+                        </span>
+                        <span id="client-available" class="bp-client-available keyed-lang-string hidden"
+                            data-key="editor_client_available">
+                        </span>
+                        <span id="client-available-short" class="bp-client-available keyed-lang-string hidden"
+                            data-key="editor_client_available_short">
+                        </span>
+                    </span>
+                </div>
+
+                <!-- Display current project name -->
+                <div id="project-details" class="project-name-wrapper"
+                    style="float:right; position: relative; top: 2px;">
+                    <div class="project-icon"></div>
+                    <div class="project-name" spellcheck="false"></div>
+                    <div class="project-owner" style="display: none;"></div>
+                </div>
+            </div>
+
+            <!-- Toolbars and hamburger menu -->
+            <div>
+                <!-- Left Toolbar buttons -->
+                <div id="board-action-buttons" style="padding-left: 10px; float: left;">
+                    <!-- Compile program -->
+                    <a id="prop-btn-comp" class="btn btn-success btn-circle auth-true" title=""
+                    data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="checkMarkWhite">&#x2713;</span>
+                    </a>
+
+                    <!-- Load to RAM -->
+                    <a id="prop-btn-ram" class="btn btn-success btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="downArrowWhite"></span>
+                    </a>
+
+                    <!-- Load to EEPROM -->
+                    <a id="prop-btn-eeprom" class="btn btn-success btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="downArrowBoxWhite">&gt;&gt;</span></a>
+
+                    <!-- Open a terminal -->
+                    <a id="prop-btn-term" class="btn btn-primary btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="terminalWhite">#</span>
+                    </a>
+
+                    <!-- Open a graphing window -->
+                    <a id="prop-btn-graph" class="btn btn-primary btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="graphWhite">~</span>
+                    </a>
+
+                    <!-- Find and replace - propc project type -->
+                    <a id="prop-btn-find-replace" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="searchWhite">&#x1F50E;</span>
+                    </a>
+
+                    <!-- Clean up source code -->
+                    <a id="prop-btn-pretty" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="magicWandWhite">&#x2728;</span>
+                    </a>
+
+                    <!-- Undo edits - propc project type -->
+                    <a id="prop-btn-undo" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="undoWhite">&#x293A;</span>
+                    </a>
+
+                    <!-- Redo edits - propc project type -->
+                    <a id="prop-btn-redo" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="redoWhite">&#x293B;</span>
+                    </a>
+
+                    <!-- Drop-down hardware port select -->
+                    <select id="comPort" class="dropdown port-dropdown auth-true select-css" title="Ports"
+                            data-displayas="inline-block" data-placement="left">
+                    </select>
+
+                </div>
+
+                <!-- Right Toolbar buttons and menu -->
+                <div id="right-menus" style="float:right; padding-right: 15px;">
+                    <!-- View C source code -->
+                    <a class="btn-view-blocks" id="btn-view-propc" style="display: none;">
+                            <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
+                            &nbsp;
+                            <span class="keyed-lang-string" data-key="menu_code"></span>
                         </a>
-                    </span>
-                    <span id="client-unavailable" class="bp-client-danger hidden">
-                        <a class="client-unavailable-link" data-toggle="modal" data-target="#client-download-modal"
-                            href="#">
-                            <span class="bpIcon" data-icon="dangerTriangle">!!</span>
-                            <span class="keyed-lang-string" data-key="editor_client_not-available"></span>
+
+                    <!-- View project blocks layout -->
+                    <a class="btn-view-blocks" id="btn-view-blocks" style="display: none;">
+                            <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
+                            &nbsp;
+                            <span class="keyed-lang-string" data-key="menu_blocks"></span>
                         </a>
-                    </span>
-                    <span id="client-available" class="bp-client-available keyed-lang-string hidden"
-                        data-key="editor_client_available">
-                    </span>
-                    <span id="client-available-short" class="bp-client-available keyed-lang-string hidden"
-                        data-key="editor_client_available_short">
-                    </span>
-                </span>
-            </div>
 
-            <!-- Display current project name -->
-            <div id="project-details" class="project-name-wrapper"
-                style="float:right; display: inline; position: relative; top: 2px;">
-                <span id="project-icon" class="editor-icon"></span>
-                <span class="project-name"></span>
-                <span class="project-owner"></span>
-            </div>
-        </div>
+                    <!-- View project XML code -->
+                    <a class="btn-view-blocks" id="btn-view-xml" style="display: none;">
+                            <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
+                            &nbsp;&nbsp;
+                            <span class="keyed-lang-string" data-key="editor_view_xml"></span>
+                        </a>
 
-        <!-- Toolbars and hamburger menu -->
-        <div>
-            <!-- Left Toolbar buttons -->
-            <div id="board-action-buttons" style="padding-left: 10px; display: inline;">
-                <!-- Compile program -->
-                <a id="prop-btn-comp" class="btn btn-success btn-circle auth-true" title=""
-                   data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="checkMarkWhite">&#x2713;</span>
-                </a>
-
-                <!-- Load to RAM -->
-                <a id="prop-btn-ram" class="btn btn-success btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="downArrowWhite"></span>
-                </a>
-
-                <!-- Load to EEPROM -->
-                <a id="prop-btn-eeprom" class="btn btn-success btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="downArrowBoxWhite">&gt;&gt;</span></a>
-
-                <!-- Open a terminal -->
-                <a id="prop-btn-term" class="btn btn-primary btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="terminalWhite">#</span>
-                </a>
-
-                <!-- Open a graphing window -->
-                <a id="prop-btn-graph" class="btn btn-primary btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="graphWhite">~</span>
-                </a>
-
-                <!-- Find and replace - propc project type -->
-                <a id="prop-btn-find-replace" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="searchWhite">&#x1F50E;</span>
-                </a>
-
-                <!-- Clean up source code -->
-                <a id="prop-btn-pretty" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="magicWandWhite">&#x2728;</span>
-                </a>
-
-                <!-- Undo edits - propc project type -->
-                <a id="prop-btn-undo" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="undoWhite">&#x293A;</span>
-                </a>
-
-                <!-- Redo edits - propc project type -->
-                <a id="prop-btn-redo" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="redoWhite">&#x293B;</span>
-                </a>
-
-                <!-- Drop-down hardware port select -->
-                <select id="comPort" class="dropdown port-dropdown auth-true select-css" title="Ports"
-                        data-displayas="inline-block" data-placement="left">
-                </select>
-
-            </div>
-
-            <!-- Right Toolbar buttons and menu -->
-            <div id="right-menus" style="float:right; padding-right: 15px; display: inline;">
-                <!-- View C source code -->
-                <a class="btn-view-blocks" id="btn-view-propc" style="display: none;">
-                        <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
-                        &nbsp;
-                        <span class="keyed-lang-string" data-key="menu_code"></span>
+                    <!-- New Project button -->
+                    <a id="new-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
+                        <span class="keyed-lang-string" data-key="editor_new_button"></span>
                     </a>
 
-                <!-- View project blocks layout -->
-                <a class="btn-view-blocks" id="btn-view-blocks" style="display: none;">
-                        <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
-                        &nbsp;
-                        <span class="keyed-lang-string" data-key="menu_blocks"></span>
+                    <!-- Open Project button -->
+                    <a id="open-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
+                        <span class="keyed-lang-string" data-key="editor_open_button"></span>
                     </a>
 
-                <!-- View project XML code -->
-                <a class="btn-view-blocks" id="btn-view-xml" style="display: none;">
-                        <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
-                        &nbsp;&nbsp;
-                        <span class="keyed-lang-string" data-key="editor_view_xml"></span>
+                    <!-- Save project button -->
+                    <a class="demo-function project-file-buttons" id="save-project" style="display: inline-block;" data-displayas="inline-block">
+                        <span class="keyed-lang-string" data-key="editor_save"></span>
                     </a>
 
-                <!-- New Project button -->
-                <a id="new-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
-                    <span class="keyed-lang-string" data-key="editor_new_button"></span>
-                </a>
+                    <!-- Drop-down hamburger menu -->
+                    <div class="dropdown" style="display: inline-block;">
+                        <!-- down-arrow control to open hamburger menu -->
+                        <button id="options-menu" class="btn btn-sm btn-default dropdown dropdown-toggle" type="button"
+                            data-toggle="dropdown">&#9776;<span class="caret"></span>
+                        </button>
 
-                <!-- Open Project button -->
-                <a id="open-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
-                    <span class="keyed-lang-string" data-key="editor_open_button"></span>
-                </a>
+                        <ul class="dropdown-menu pull-right btn-sm">
+                            <li class="auth-true" data-displayas="list-item">
+                                <a id="edit-project-details" href="#">
+                                    <span class="keyed-lang-string" data-key="editor_edit-details"></span>
+                                </a>
+                            </li>
 
-                <!-- Save project button -->
-                <a class="demo-function project-file-buttons" id="save-project" style="display: inline-block;" data-displayas="inline-block">
-                    <span class="keyed-lang-string" data-key="editor_save"></span>
-                </a>
+                            <!-- New Project menu item
+                            <li class="auth-true offline-only hidden" data-displayas="list-item">
+                                <a id="new-project-menu-item" href="#" class="url-prefix">
+                                    <span class="keyed-lang-string" data-key="menu_newproject_title"></span>
+                                </a>
+                            </li>
+                            -->
 
-                <!-- Drop-down hamburger menu -->
-                <div class="dropdown" style="display: inline-block;">
-                    <!-- down-arrow control to open hamburger menu -->
-                    <button id="options-menu" class="btn btn-sm btn-default dropdown dropdown-toggle" type="button"
-                        data-toggle="dropdown">&#9776;<span class="caret"></span>
-                    </button>
+                            <li class="online-only divider"></li>
 
-                    <ul class="dropdown-menu pull-right btn-sm">
-                        <li class="auth-true" data-displayas="list-item">
-                            <a id="edit-project-details" href="#">
-                                <span class="keyed-lang-string" data-key="editor_edit-details"></span>
-                            </a>
-                        </li>
+                            <li>
+                                <a id="online-help" class="url-prefix" href="https://learn.parallax.com/ab-blocks" target="_blank">
+                                    <span class="keyed-lang-string" data-key="menu_help_reference"></span>
+                                </a>
+                            </li>
 
-                        <!-- New Project menu item
-                        <li class="auth-true offline-only hidden" data-displayas="list-item">
-                            <a id="new-project-menu-item" href="#" class="url-prefix">
-                                <span class="keyed-lang-string" data-key="menu_newproject_title"></span>
-                            </a>
-                        </li>
-                        -->
+                            <li class="divider"></li>
 
-                        <li class="online-only divider"></li>
+                            <li>
+                                <a id="download-side" href="#">
+                                    <span class="keyed-lang-string" data-key="menu_download_simpleide"></span>
+                                </a>
+                            </li>
 
-                        <li>
-                            <a id="online-help" class="url-prefix" href="https://learn.parallax.com/ab-blocks" target="_blank">
-                                <span class="keyed-lang-string" data-key="menu_help_reference"></span>
-                            </a>
-                        </li>
+                            <!-- Download blocks file
+                            <li>
+                                <a id="download-project" href="#">
+                                    <span class="keyed-lang-string" data-key="editor_download"></span>
+                                </a>
+                            </li>
+                            -->
 
-                        <li class="divider"></li>
+                            <li class="auth-true" data-displayas="list-item">
+                                <a id="upload-project">
+                                    <span class="keyed-lang-string" data-key="editor_upload"></span>
+                                </a>
+                            </li>
 
-                        <li>
-                            <a id="download-side" href="#">
-                                <span class="keyed-lang-string" data-key="menu_download_simpleide"></span>
-                            </a>
-                        </li>
+                            <li class="auth-true divider" data-displayas="list-item"></li>
 
-                        <!-- Download blocks file
-                        <li>
-                            <a id="download-project" href="#">
-                                <span class="keyed-lang-string" data-key="editor_download"></span>
-                            </a>
-                        </li>
-                        -->
-
-                        <li class="auth-true" data-displayas="list-item">
-                            <a id="upload-project">
-                                <span class="keyed-lang-string" data-key="editor_upload"></span>
-                            </a>
-                        </li>
-
-                        <li class="auth-true divider" data-displayas="list-item"></li>
-
-                        <li class="auth-true" data-displayas="list-item">
-                            <a id="client-setup">
-                                <span class="keyed-lang-string" data-key="editor_run_configure"></span>
-                            </a>
-                        </li>
-                    </ul>
+                            <li class="auth-true" data-displayas="list-item">
+                                <a id="client-setup">
+                                    <span class="keyed-lang-string" data-key="editor_run_configure"></span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/blocklyc.js
+++ b/src/blocklyc.js
@@ -575,7 +575,7 @@ function cloudCompile(text, action, successHandler) {
             if (docker) {
                 // Contact the local docker container running cloud compiler
 
-                // baseUrl = /blockly/
+                // BASE_URL = /blockly/
                 // action = 'compile'
                 // idProject = an integer project number
                 // data = {'code: propCode}
@@ -651,7 +651,7 @@ function cloudCompile(text, action, successHandler) {
         else {  // ONLINE MODE
             $.ajax({
                 'method': 'POST',
-                'url': baseUrl + 'rest/compile/c/' + action + '?id=' + idProject,
+                'url': BASE_URL + 'rest/compile/c/' + action + '?id=' + idProject,
                 'data': {"code": propcCode}
             }).done(function (data) {
                 if (data.error || typeof data.error === "undefined") {

--- a/src/deprecated/project.js
+++ b/src/deprecated/project.js
@@ -25,7 +25,7 @@
  *
  * @type {*|jQuery}
  */
-var baseUrl = $("meta[name=base]").attr("content");
+var BASE_URL = $("meta[name=base]").attr("content");
 
 
 /**
@@ -137,7 +137,7 @@ $(function () {
     $("#project-link-share-enable").click(function () {
         var linkShareInput = $("#project-link-share");
         if ($(this).prop('checked')) {
-            $.post(baseUrl + "projectlink", {'id': idProject, 'action': 'share'}, function (response) {
+            $.post(BASE_URL + "projectlink", {'id': idProject, 'action': 'share'}, function (response) {
                 if (response['success']) {
                     linkShareInput.val(window.location.origin + linkShareUrl + idProject + "&key=" + response['share-key']);
                     linkShareInput.focus();
@@ -152,7 +152,7 @@ $(function () {
 
 
         } else {
-            $.post(baseUrl + "projectlink", {'id': idProject, 'action': 'revoke'}, function (response) {
+            $.post(BASE_URL + "projectlink", {'id': idProject, 'action': 'revoke'}, function (response) {
                 if (response['success']) {
                     linkShareInput.tooltip('destroy');
                     linkShareInput.val('');
@@ -212,7 +212,7 @@ function loadProject(idProject) {
     $("#project-link-share-enable").prop('checked', false);
 
     // Get details
-    $.get(baseUrl + "rest/shared/project/get/" + idProject, function (project) {
+    $.get(BASE_URL + "rest/shared/project/get/" + idProject, function (project) {
         if (project['yours']) {
             $('.your-project').removeClass('hidden');
 
@@ -253,7 +253,7 @@ function loadProject(idProject) {
 
         var openProjectLink = $("a.open-project-link");
         openProjectLink.removeClass("editor-c-link editor-spin-link");
-        openProjectLink.attr("href", baseUrl + "editor/" + projectTypes[project['type']]['editor'] + "?project=" + project['id']);
+        openProjectLink.attr("href", BASE_URL + "editor/" + projectTypes[project['type']]['editor'] + "?project=" + project['id']);
         $('.clone-project').attr('href', cloneUrl + project['id']);
         $('.delete-project').attr('href', deleteUrl + project['id']);
         openProjectLink.addClass(projectTypes[project['type']]['class']);

--- a/src/deprecated/shared-editor-demo.js
+++ b/src/deprecated/shared-editor-demo.js
@@ -30,7 +30,7 @@
 // TODO: This file is not referenced anywhere within the Solo project
 
 
-var baseUrl = $("meta[name=base]").attr("content");
+var BASE_URL = $("meta[name=base]").attr("content");
 
 
 var projectData = {

--- a/src/deprecated/shared-editor.js
+++ b/src/deprecated/shared-editor.js
@@ -29,7 +29,7 @@
 
 // TODO: This file is not referenced anywhere within the Solo project
 
-var baseUrl = $("meta[name=base]").attr("content");
+var BASE_URL = $("meta[name=base]").attr("content");
 
 var projectData = null;
 var ready = false;
@@ -63,13 +63,13 @@ showInfo = function (data) {
 saveProject = function () {
     var code = window.frames["content_blocks"].getXml();
     projectData['code'] = code;
-    $.post(baseUrl + 'rest/project/code', projectData, function (data) {
+    $.post(BASE_URL + 'rest/project/code', projectData, function (data) {
         var previousOwner = projectData['yours'];
         projectData = data;
         projectData['code'] = code; // Save code in projectdata to be able to verify if code has changed upon leave
         utils.showMessage("Project saved", "The project has been saved");
         if (!previousOwner) {
-            window.location.href = baseUrl + 'projecteditor?id=' + data['id'];
+            window.location.href = BASE_URL + 'projecteditor?id=' + data['id'];
         }
     });
 };
@@ -115,5 +115,5 @@ checkLeave = function () {
 };
 
 setInterval(function () {
-    $.get(baseUrl + 'ping');
+    $.get(BASE_URL + 'ping');
 }, 60000);

--- a/src/editor.js
+++ b/src/editor.js
@@ -622,6 +622,19 @@ function initEventHandlers() {
     // **********************************
     // **     Toolbar - right side     **
     // **********************************
+    // Project Name listing
+    // Make the text in the project-name span editable
+    $('.project-name').attr('contenteditable', 'true')  
+            // Change the styling to indicate to the user that they are editing this field        
+            .on('focus', () => {
+                $('.project-name').addClass('project-name-editable');
+            })
+            // reset the style and save the new project name to the projectData object 
+            .on('blur', () => {
+                $('.project-name').removeClass('project-name-editable');
+                projectData.name = $('.project-name').html();
+            });
+
     // New Project toolbar button
     $('#new-project-button').on('click', () => NewProjectModal());
 
@@ -753,8 +766,6 @@ function initCdnImageUrls() {
         }
     });
 }
-
-
 
 /**
  * Reset the sizing of blockly's toolbox and canvas.

--- a/src/modals.js
+++ b/src/modals.js
@@ -164,7 +164,7 @@ function NewProjectModalCancelClick() {
 
         if (! projectData) {
             // If there is no project, go to home page.
-            window.location.href = (isOffline) ? 'index.html' : baseUrl;
+            window.location.href = (isOffline) ? 'index.html' : BASE_URL;
         }
 
         // if the project is being edited, clear the fields and close the modal
@@ -244,7 +244,7 @@ function CreateNewProject() {
     if (projectData && $('#new-project-dialog-title').html() === page_text_label['editor_edit-details']) {
         code = getXml();
     } else {
-        code = EmptyProjectCodeHeader;
+        code = EMPTY_PROJECT_CODE_HEADER;
     }
 
     // Save the form fields into the projectData object
@@ -273,7 +273,7 @@ function CreateNewProject() {
 
     // Save the project to the browser local store for the
     // page transition
-    window.localStorage.setItem(localProjectStoreName, JSON.stringify(projectData));
+    window.localStorage.setItem(LOCAL_PROJECT_STORE_NAME, JSON.stringify(projectData));
 
     // ------------------------------------------------------
     // Clear the projectData global to prevent the onLeave
@@ -313,17 +313,17 @@ function OpenProjectModal() {
         // A copy of the current project is located in the browser localStorage
         setupWorkspace( projectData,
             function () {
-                window.localStorage.removeItem(localProjectStoreName);
+                window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
             });
     });
 
 
     $('#open-project-select-file-open').on( 'click', () => {
-        if (window.localStorage.getItem(tempProjectStoreName)) {
+        if (window.localStorage.getItem(TEMP_PROJECT_STORE_NAME)) {
             window.localStorage.setItem(
-                localProjectStoreName,
-                window.localStorage.getItem(tempProjectStoreName));
-            window.localStorage.removeItem(tempProjectStoreName);
+                LOCAL_PROJECT_STORE_NAME,
+                window.localStorage.getItem(TEMP_PROJECT_STORE_NAME));
+            window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
             window.location = 'blocklyc.html';
         }
     });
@@ -332,7 +332,7 @@ function OpenProjectModal() {
     $('#open-project-dialog').modal({keyboard: false, backdrop: 'static'});
 
     // If the user selects a file and successfully uploads it, the
-    // project will be stored in localStorage.tempProjectStoreName.
+    // project will be stored in localStorage.TEMP_PROJECT_STORE_NAME.
     // The form Accept button handler should look there when it is
     // time to proces the new project.
 }
@@ -366,8 +366,8 @@ function OpenProjectFileDialog() {
     // TODO: what is this doing here? Shouldn't we be setting up projectData instead of localStore?
     //       Or can this simply be deleted, because the openFile functions will take care of this?
     if (projectData) {
-        console.log("Loading workspace with project %s", localProjectStoreName);
-        setupWorkspace(JSON.parse(window.localStorage.getItem(localProjectStoreName)));
+        console.log("Loading workspace with project %s", LOCAL_PROJECT_STORE_NAME);
+        setupWorkspace(JSON.parse(window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)));
     }
 }
 

--- a/src/style-editor.css
+++ b/src/style-editor.css
@@ -469,6 +469,17 @@ ul > hr {
     padding-right: 10px;
 }
 
+.project-name:focus {
+    outline: none;
+}
+
+.project-name-editable {
+    border: 3px solid #00f;
+    border-radius: 5px;
+    padding: 0px 5px;
+    background-color: white;
+}
+
 .bp-client-available {
     background:none;
     border:1px solid rgba(0, 0, 0, 0);

--- a/src/style-editor.css
+++ b/src/style-editor.css
@@ -469,6 +469,15 @@ ul > hr {
     padding-right: 10px;
 }
 
+.project-name {
+    max-width: 250px;
+    text-overflow: clip;
+    overflow: hidden;
+    overflow-wrap: normal;
+    white-space: nowrap;
+    text-align: left;
+}
+
 .project-name:focus {
     outline: none;
 }
@@ -478,6 +487,11 @@ ul > hr {
     border-radius: 5px;
     padding: 0px 5px;
     background-color: white;
+}
+
+.project-icon {
+    float: left; 
+    padding-right: 5px
 }
 
 .bp-client-available {


### PR DESCRIPTION
Makes the project name editable, and after editing, updates the projectData object with the new name.

Setting a default name, etc. can (and should be) be dealt with in issue #115.

To Test:
1.) click the project name in the top-right corner
2.) Make sure the styling changes (blue outline)
3.) edit/change the project name
4.) when you click elsewhere (de-focus the project name), the styling should return to normal.
5.) Choose "edit project details" in the hamburger menu to make sure the new project name persists.