### PR TITLE
Remove duplicate styling, make buttons readable on hover

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -240,17 +240,17 @@
                     </a>
 
                 <!-- New Project button -->
-                <a id="new-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
+                <a id="new-project-button" class="demo-function btn-view-blocks" style="display: inline-block;" data-displayas="inline-block">
                     <span class="keyed-lang-string" data-key="editor_new_button"></span>
                 </a>
 
                 <!-- Open Project button -->
-                <a id="open-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
+                <a id="open-project-button" class="demo-function btn-view-blocks" style="display: inline-block;" data-displayas="inline-block">
                     <span class="keyed-lang-string" data-key="editor_open_button"></span>
                 </a>
 
                 <!-- Save project button -->
-                <a class="demo-function project-file-buttons" id="save-project" style="display: inline-block;" data-displayas="inline-block">
+                <a class="demo-function btn-view-blocks" id="save-project" style="display: inline-block;" data-displayas="inline-block">
                     <span class="keyed-lang-string" data-key="editor_save"></span>
                 </a>
 

--- a/src/style-editor.css
+++ b/src/style-editor.css
@@ -51,7 +51,7 @@ html, body {
 }
 
 
-.blocklyWidgetDiv .goog-menuitem-content, .blocklyContextMenu, .blocklydropdownmenu {
+.blocklyWidgetDiv .goog-menuitem-content, .blocklyContextMenu, .blocklyDropdownMenu {
     font: normal 14px Arimo, sans-serif !important;
     max-height: 110% !important;
 }
@@ -282,36 +282,6 @@ ul > hr {
 }
 
 /* Editor toolbar New, Open, and Save buttons */
-.project-file-buttons {
-    -webkit-transition: padding-left 1s, background 1s, border 1s;
-    transition: padding-left 1s, background 1s, border 1s;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    padding-left: 15px;
-    font-size: 12px;
-    line-height: 1.5;
-    color: #fff;
-    width: 60px;
-    background-color: #337ab7;
-    display: inline-block;
-    margin-bottom: 0;
-    text-align: left;
-    white-space: nowrap;
-    vertical-align: middle;
-    cursor: pointer;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    text-decoration: none;
-}
-
-/* Editor toolbar New, Open, and Save buttons */
-.project-file-buttons:hover {
-    box-shadow: 2px 2px 5px #89a;
-    background-color: #286090;
-    border-color: rgb(32, 77, 116);
-}
-
-
 .btn-view-blocks:hover {
     box-shadow: 2px 2px 5px #89a;
     color: #fff;


### PR DESCRIPTION
Addresses #119 
Corrects a few small styling issues to improve readability in the top nav bar and on block dropdowns:

To test:
1.) hover over each button to make sure it is readable in it's highlighted state
2.) choose any block that has a dropdown menu.  When the dropdown is selected, there should not be a vertical scrollbar (caused by the max-height property being too small)