### PR TITLE
Make project name editable - Deconflicted

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -116,206 +116,208 @@
         <div id="branding" style="position: relative; top: 2px;">
             <a id="nav-logo" href="/" class="url-prefix"></a>
         </div>
-
-        <!-- Above toolbar -->
         <div>
-            <!-- BlocklyProp Client or Loader UI -->
-            <div id="client-status-alerts" style="display: inline;">
-                <span class="auth-true" style="padding-left: 10px; line-height: 30px;">
-                    <span id="client-searching" class="bp-client-warning">
-                        <a class="client-searching-link" data-toggle="modal" data-target="#client-download-modal"
-                            href="#">
-                            <span class="bpIcon" data-icon="warningCircle">!</span>
-                            <span class="keyed-lang-string" data-key="editor_client_checking"></span>
+            <!-- Above toolbar -->
+            <div style="overflow:auto;">
+
+                <!-- BlocklyProp Client or Loader UI -->
+                <div id="client-status-alerts" style="float: left;">
+                    <span class="auth-true" style="padding-left: 10px; line-height: 30px;">
+                        <span id="client-searching" class="bp-client-warning">
+                            <a class="client-searching-link" data-toggle="modal" data-target="#client-download-modal"
+                                href="#">
+                                <span class="bpIcon" data-icon="warningCircle">!</span>
+                                <span class="keyed-lang-string" data-key="editor_client_checking"></span>
+                            </a>
+                        </span>
+                        <span id="client-unavailable" class="bp-client-danger hidden">
+                            <a class="client-unavailable-link" data-toggle="modal" data-target="#client-download-modal"
+                                href="#">
+                                <span class="bpIcon" data-icon="dangerTriangle">!!</span>
+                                <span class="keyed-lang-string" data-key="editor_client_not-available"></span>
+                            </a>
+                        </span>
+                        <span id="client-available" class="bp-client-available keyed-lang-string hidden"
+                            data-key="editor_client_available">
+                        </span>
+                        <span id="client-available-short" class="bp-client-available keyed-lang-string hidden"
+                            data-key="editor_client_available_short">
+                        </span>
+                    </span>
+                </div>
+
+                <!-- Display current project name -->
+                <div id="project-details" class="project-name-wrapper"
+                    style="float:right; position: relative; top: 2px;">
+                    <div class="project-icon"></div>
+                    <div class="project-name" spellcheck="false"></div>
+                    <div class="project-owner" style="display: none;"></div>
+                </div>
+            </div>
+
+            <!-- Toolbars and hamburger menu -->
+            <div>
+                <!-- Left Toolbar buttons -->
+                <div id="board-action-buttons" style="padding-left: 10px; float: left;">
+                    <!-- Compile program -->
+                    <a id="prop-btn-comp" class="btn btn-success btn-circle auth-true" title=""
+                    data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="checkMarkWhite">&#x2713;</span>
+                    </a>
+
+                    <!-- Load to RAM -->
+                    <a id="prop-btn-ram" class="btn btn-success btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="downArrowWhite"></span>
+                    </a>
+
+                    <!-- Load to EEPROM -->
+                    <a id="prop-btn-eeprom" class="btn btn-success btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="downArrowBoxWhite">&gt;&gt;</span></a>
+
+                    <!-- Open a terminal -->
+                    <a id="prop-btn-term" class="btn btn-primary btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="terminalWhite">#</span>
+                    </a>
+
+                    <!-- Open a graphing window -->
+                    <a id="prop-btn-graph" class="btn btn-primary btn-circle disabled auth-true" title=""
+                    data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
+                        <span class="bpIcon" data-icon="graphWhite">~</span>
+                    </a>
+
+                    <!-- Find and replace - propc project type -->
+                    <a id="prop-btn-find-replace" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="searchWhite">&#x1F50E;</span>
+                    </a>
+
+                    <!-- Clean up source code -->
+                    <a id="prop-btn-pretty" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="magicWandWhite">&#x2728;</span>
+                    </a>
+
+                    <!-- Undo edits - propc project type -->
+                    <a id="prop-btn-undo" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="undoWhite">&#x293A;</span>
+                    </a>
+
+                    <!-- Redo edits - propc project type -->
+                    <a id="prop-btn-redo" class="btn btn-info btn-circle propc-only hidden" title=""
+                    data-toggle="tooltip" data-placement="bottom">
+                        <span class="bpIcon" data-icon="redoWhite">&#x293B;</span>
+                    </a>
+
+                    <!-- Drop-down hardware port select -->
+                    <select id="comPort" class="dropdown port-dropdown auth-true select-css" title="Ports"
+                            data-displayas="inline-block" data-placement="left">
+                    </select>
+
+                </div>
+
+                <!-- Right Toolbar buttons and menu -->
+                <div id="right-menus" style="float:right; padding-right: 15px;">
+                    <!-- View C source code -->
+                    <a class="btn-view-blocks" id="btn-view-propc" style="display: none;">
+                            <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
+                            &nbsp;
+                            <span class="keyed-lang-string" data-key="menu_code"></span>
                         </a>
-                    </span>
-                    <span id="client-unavailable" class="bp-client-danger hidden">
-                        <a class="client-unavailable-link" data-toggle="modal" data-target="#client-download-modal"
-                            href="#">
-                            <span class="bpIcon" data-icon="dangerTriangle">!!</span>
-                            <span class="keyed-lang-string" data-key="editor_client_not-available"></span>
+
+                    <!-- View project blocks layout -->
+                    <a class="btn-view-blocks" id="btn-view-blocks" style="display: none;">
+                            <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
+                            &nbsp;
+                            <span class="keyed-lang-string" data-key="menu_blocks"></span>
                         </a>
-                    </span>
-                    <span id="client-available" class="bp-client-available keyed-lang-string hidden"
-                        data-key="editor_client_available">
-                    </span>
-                    <span id="client-available-short" class="bp-client-available keyed-lang-string hidden"
-                        data-key="editor_client_available_short">
-                    </span>
-                </span>
-            </div>
 
-            <!-- Display current project name -->
-            <div id="project-details" class="project-name-wrapper"
-                style="float:right; display: inline; position: relative; top: 2px;">
-                <span id="project-icon" class="editor-icon"></span>
-                <span class="project-name"></span>
-                <span class="project-owner"></span>
-            </div>
-        </div>
+                    <!-- View project XML code -->
+                    <a class="btn-view-blocks" id="btn-view-xml" style="display: none;">
+                            <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
+                            &nbsp;&nbsp;
+                            <span class="keyed-lang-string" data-key="editor_view_xml"></span>
+                        </a>
 
-        <!-- Toolbars and hamburger menu -->
-        <div>
-            <!-- Left Toolbar buttons -->
-            <div id="board-action-buttons" style="padding-left: 10px; display: inline;">
-                <!-- Compile program -->
-                <a id="prop-btn-comp" class="btn btn-success btn-circle auth-true" title=""
-                   data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="checkMarkWhite">&#x2713;</span>
-                </a>
-
-                <!-- Load to RAM -->
-                <a id="prop-btn-ram" class="btn btn-success btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="downArrowWhite"></span>
-                </a>
-
-                <!-- Load to EEPROM -->
-                <a id="prop-btn-eeprom" class="btn btn-success btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="downArrowBoxWhite">&gt;&gt;</span></a>
-
-                <!-- Open a terminal -->
-                <a id="prop-btn-term" class="btn btn-primary btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="terminalWhite">#</span>
-                </a>
-
-                <!-- Open a graphing window -->
-                <a id="prop-btn-graph" class="btn btn-primary btn-circle disabled auth-true" title=""
-                   data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
-                    <span class="bpIcon" data-icon="graphWhite">~</span>
-                </a>
-
-                <!-- Find and replace - propc project type -->
-                <a id="prop-btn-find-replace" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="searchWhite">&#x1F50E;</span>
-                </a>
-
-                <!-- Clean up source code -->
-                <a id="prop-btn-pretty" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="magicWandWhite">&#x2728;</span>
-                </a>
-
-                <!-- Undo edits - propc project type -->
-                <a id="prop-btn-undo" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="undoWhite">&#x293A;</span>
-                </a>
-
-                <!-- Redo edits - propc project type -->
-                <a id="prop-btn-redo" class="btn btn-info btn-circle propc-only hidden" title=""
-                   data-toggle="tooltip" data-placement="bottom">
-                    <span class="bpIcon" data-icon="redoWhite">&#x293B;</span>
-                </a>
-
-                <!-- Drop-down hardware port select -->
-                <select id="comPort" class="dropdown port-dropdown auth-true select-css" title="Ports"
-                        data-displayas="inline-block" data-placement="left">
-                </select>
-
-            </div>
-
-            <!-- Right Toolbar buttons and menu -->
-            <div id="right-menus" style="float:right; padding-right: 15px; display: inline;">
-                <!-- View C source code -->
-                <a class="btn-view-blocks" id="btn-view-propc" style="display: none;">
-                        <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
-                        &nbsp;
-                        <span class="keyed-lang-string" data-key="menu_code"></span>
+                    <!-- New Project button -->
+                    <a id="new-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
+                        <span class="keyed-lang-string" data-key="editor_new_button"></span>
                     </a>
 
-                <!-- View project blocks layout -->
-                <a class="btn-view-blocks" id="btn-view-blocks" style="display: none;">
-                        <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
-                        &nbsp;
-                        <span class="keyed-lang-string" data-key="menu_blocks"></span>
+                    <!-- Open Project button -->
+                    <a id="open-project-button" class="demo-function project-file-buttons" style="display: inline-block;" data-displayas="inline-block">
+                        <span class="keyed-lang-string" data-key="editor_open_button"></span>
                     </a>
 
-                <!-- View project XML code -->
-                <a class="btn-view-blocks" id="btn-view-xml" style="display: none;">
-                        <span class="bpIcon" data-icon="eyeWhite">&#x1F441;</span>
-                        &nbsp;&nbsp;
-                        <span class="keyed-lang-string" data-key="editor_view_xml"></span>
+                    <!-- Save project button -->
+                    <a class="demo-function project-file-buttons" id="save-project" style="display: inline-block;" data-displayas="inline-block">
+                        <span class="keyed-lang-string" data-key="editor_save"></span>
                     </a>
 
-                <!-- New Project button -->
-                <a id="new-project-button" class="demo-function btn-view-blocks" style="display: inline-block;" data-displayas="inline-block">
-                    <span class="keyed-lang-string" data-key="editor_new_button"></span>
-                </a>
+                    <!-- Drop-down hamburger menu -->
+                    <div class="dropdown" style="display: inline-block;">
+                        <!-- down-arrow control to open hamburger menu -->
+                        <button id="options-menu" class="btn btn-sm btn-default dropdown dropdown-toggle" type="button"
+                            data-toggle="dropdown">&#9776;<span class="caret"></span>
+                        </button>
 
-                <!-- Open Project button -->
-                <a id="open-project-button" class="demo-function btn-view-blocks" style="display: inline-block;" data-displayas="inline-block">
-                    <span class="keyed-lang-string" data-key="editor_open_button"></span>
-                </a>
+                        <ul class="dropdown-menu pull-right btn-sm">
+                            <li class="auth-true" data-displayas="list-item">
+                                <a id="edit-project-details" href="#">
+                                    <span class="keyed-lang-string" data-key="editor_edit-details"></span>
+                                </a>
+                            </li>
 
-                <!-- Save project button -->
-                <a class="demo-function btn-view-blocks" id="save-project" style="display: inline-block;" data-displayas="inline-block">
-                    <span class="keyed-lang-string" data-key="editor_save"></span>
-                </a>
+                            <!-- New Project menu item
+                            <li class="auth-true offline-only hidden" data-displayas="list-item">
+                                <a id="new-project-menu-item" href="#" class="url-prefix">
+                                    <span class="keyed-lang-string" data-key="menu_newproject_title"></span>
+                                </a>
+                            </li>
+                            -->
 
-                <!-- Drop-down hamburger menu -->
-                <div class="dropdown" style="display: inline-block;">
-                    <!-- down-arrow control to open hamburger menu -->
-                    <button id="options-menu" class="btn btn-sm btn-default dropdown dropdown-toggle" type="button"
-                        data-toggle="dropdown">&#9776;<span class="caret"></span>
-                    </button>
+                            <li class="online-only divider"></li>
 
-                    <ul class="dropdown-menu pull-right btn-sm">
-                        <li class="auth-true" data-displayas="list-item">
-                            <a id="edit-project-details" href="#">
-                                <span class="keyed-lang-string" data-key="editor_edit-details"></span>
-                            </a>
-                        </li>
+                            <li>
+                                <a id="online-help" class="url-prefix" href="https://learn.parallax.com/ab-blocks" target="_blank">
+                                    <span class="keyed-lang-string" data-key="menu_help_reference"></span>
+                                </a>
+                            </li>
 
-                        <!-- New Project menu item
-                        <li class="auth-true offline-only hidden" data-displayas="list-item">
-                            <a id="new-project-menu-item" href="#" class="url-prefix">
-                                <span class="keyed-lang-string" data-key="menu_newproject_title"></span>
-                            </a>
-                        </li>
-                        -->
+                            <li class="divider"></li>
 
-                        <li class="online-only divider"></li>
+                            <li>
+                                <a id="download-side" href="#">
+                                    <span class="keyed-lang-string" data-key="menu_download_simpleide"></span>
+                                </a>
+                            </li>
 
-                        <li>
-                            <a id="online-help" class="url-prefix" href="https://learn.parallax.com/ab-blocks" target="_blank">
-                                <span class="keyed-lang-string" data-key="menu_help_reference"></span>
-                            </a>
-                        </li>
+                            <!-- Download blocks file
+                            <li>
+                                <a id="download-project" href="#">
+                                    <span class="keyed-lang-string" data-key="editor_download"></span>
+                                </a>
+                            </li>
+                            -->
 
-                        <li class="divider"></li>
+                            <li class="auth-true" data-displayas="list-item">
+                                <a id="upload-project">
+                                    <span class="keyed-lang-string" data-key="editor_upload"></span>
+                                </a>
+                            </li>
 
-                        <li>
-                            <a id="download-side" href="#">
-                                <span class="keyed-lang-string" data-key="menu_download_simpleide"></span>
-                            </a>
-                        </li>
+                            <li class="auth-true divider" data-displayas="list-item"></li>
 
-                        <!-- Download blocks file
-                        <li>
-                            <a id="download-project" href="#">
-                                <span class="keyed-lang-string" data-key="editor_download"></span>
-                            </a>
-                        </li>
-                        -->
-
-                        <li class="auth-true" data-displayas="list-item">
-                            <a id="upload-project">
-                                <span class="keyed-lang-string" data-key="editor_upload"></span>
-                            </a>
-                        </li>
-
-                        <li class="auth-true divider" data-displayas="list-item"></li>
-
-                        <li class="auth-true" data-displayas="list-item">
-                            <a id="client-setup">
-                                <span class="keyed-lang-string" data-key="editor_run_configure"></span>
-                            </a>
-                        </li>
-                    </ul>
+                            <li class="auth-true" data-displayas="list-item">
+                                <a id="client-setup">
+                                    <span class="keyed-lang-string" data-key="editor_run_configure"></span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,42 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "abab": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.2.tgz",
@@ -65,6 +101,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
@@ -103,6 +145,12 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -115,6 +163,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -184,16 +238,42 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -212,6 +292,12 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -226,6 +312,42 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -322,15 +444,45 @@
         "ms": "^2.1.1"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -363,6 +515,35 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "es-abstract": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -558,6 +739,24 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -596,10 +795,28 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "getpass": {
@@ -639,6 +856,12 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -653,10 +876,31 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -749,6 +993,24 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -776,10 +1038,34 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -891,6 +1177,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -898,6 +1190,16 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -909,6 +1211,21 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
@@ -953,6 +1270,83 @@
         "minimist": "0.0.8"
       }
     },
+    "mocha": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -977,6 +1371,37 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "nwsapi": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
@@ -986,6 +1411,40 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1024,6 +1483,30 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1038,6 +1521,12 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
       "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1048,6 +1537,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "performance-now": {
@@ -1164,6 +1668,18 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1231,6 +1747,12 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1251,6 +1773,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      }
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -1313,6 +1850,26 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^5.2.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "strip-ansi": {
@@ -1447,6 +2004,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
@@ -1537,10 +2100,94 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1574,6 +2221,76 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "jquery": "^3.4.1"
   },
   "devDependencies": {
-    "eslint": "^6.6.0"
+    "chai": "^4.2.0",
+    "eslint": "^6.6.0",
+    "mocha": "^6.2.2",
+    "sinon": "^7.5.0"
   }
 }

--- a/src/editor.js
+++ b/src/editor.js
@@ -36,7 +36,7 @@
  *
  * @type {*|jQuery}
  */
-const baseUrl = $('meta[name=base]').attr("content");
+const BASE_URL = $('meta[name=base]').attr("content");
 
 
 /*
@@ -55,7 +55,7 @@ const baseUrl = $('meta[name=base]').attr("content");
  *
  * @type {*|jQuery}
  */
-const cdnUrl = $('meta[name=cdn]').attr("content");
+const CDN_URL = $('meta[name=cdn]').attr("content");
 
 
 
@@ -71,6 +71,36 @@ const cdnUrl = $('meta[name=cdn]').attr("content");
  * @description Converting the string to a constant because it is referenced
  * in a number of places. The string is sufficiently complex that it could
  * be misspelled without detection.
+<<<<<<< HEAD
+=======
+ */
+const EMPTY_PROJECT_CODE_HEADER = '<xml xmlns="http://www.w3.org/1999/xhtml">';
+
+
+/**
+ * Constant number that represents the maximum length of a project name
+ *
+ * @type {number}
+ */
+const PROJECT_NAME_MAX_LENGTH = 100;
+
+
+/**
+ * Constant number that represents the maximum number of 
+ * characters of the project name that are displayed in the UI
+ *
+ * @type {number}
+ */
+const PROJECT_NAME_DISPLAY_MAX_LENGTH = 24;
+
+
+/**
+ * Force the saveCheck() function to exit immediately with a false result
+ *
+ * TODO: This flag is used in exactly one place. Why do we need it?
+ *
+ * @type {boolean}
+>>>>>>> 064f697b6770aa2a91ae8dc0c6775c1f4007a993
  *
  * /
  // Moved to project.js
@@ -150,8 +180,8 @@ bpIcons = {
  *
  * @type {string}
  */
-const tempProjectStoreName = "tempProject";
-const localProjectStoreName = 'localProject';
+const TEMP_PROJECT_STORE_NAME = "tempProject";
+const LOCAL_PROJECT_STORE_NAME = 'localProject';
 
 
 /**
@@ -166,7 +196,7 @@ var blocklyWorkSpace;
  *
  * @type {number}
  */
-const defaultSaveProjectTimerDelay = 20;
+const SAVE_PROJECT_TIMER_DELAY = 20;
 
 
 // TODO: set up a markdown editor (removed because it doesn't work in a Bootstrap modal...)
@@ -295,7 +325,7 @@ $(() => {
                 tempProject.code = getXml();
                 tempProject.timestamp = getTimestamp();
 
-                window.localStorage.setItem(localProjectStoreName, JSON.stringify(tempProject));
+                window.localStorage.setItem(LOCAL_PROJECT_STORE_NAME, JSON.stringify(tempProject));
             }
         }
 
@@ -319,7 +349,7 @@ $(() => {
     $('#upload-dialog').on('hidden.bs.modal', resetUploadImportModalDialog());
 
     $('.url-prefix').attr('href', function (idx, cur) {
-        return baseUrl + cur;
+        return BASE_URL + cur;
     });
 
     initCdnImageUrls();
@@ -524,10 +554,33 @@ function initEventHandlers() {
     // **********************************
     // **     Toolbar - right side     **
     // **********************************
-    // Blocks/Code/XML button
-    $('#btn-view-propc').on('click', () => renderContent('tab_propc'));
-    $('#btn-view-blocks').on('click', () => renderContent('tab_blocks'));
-    $('#btn-view-xml').on('click', () => renderContent('tab_xml'));
+    // Project Name listing
+
+    // Make the text in the project-name span editable
+    $('.project-name').attr('contenteditable', 'true')  
+
+            // Change the styling to indicate to the user that they are editing this field
+            .on('focus', () => {
+                $('.project-name').html(projectData.name);
+                $('.project-name').addClass('project-name-editable');
+            })
+            // reset the style and save the new project name to the projectData object 
+            .on('blur', () => {
+                $('.project-name').removeClass('project-name-editable');
+                // if the project name is greater than 25 characters, only display the first 25
+                if (projectData.name.length > PROJECT_NAME_DISPLAY_MAX_LENGTH) {
+                    $('.project-name').html(projectData.name.substring(0,PROJECT_NAME_DISPLAY_MAX_LENGTH - 1) + '...');
+                }
+            })
+            // validate the input to ensure it's not too long, and save changes as the user types.
+            .on('keyup', () => {
+                var tempProjectName = $('.project-name').html()
+                if (tempProjectName.length > PROJECT_NAME_MAX_LENGTH) {
+                    $('.project-name').html(projectData.name);
+                } else {
+                    projectData.name = tempProjectName;
+                }
+            });
 
     // New Project toolbar button
     $('#new-project-button').on('click', () => NewProjectModal());
@@ -677,7 +730,7 @@ function initCdnImageUrls() {
         // Set the source of the image
         let img_source = img_tag.attr('data-src');
         if (img_source) {
-            img_tag.attr('src', cdnUrl + img_source);
+            img_tag.attr('src', CDN_URL + img_source);
         }
     });
 }
@@ -800,7 +853,7 @@ function setupWorkspace(data, callback) {
     }
 
     resetToolBoxSizing();
-    timestampSaveTime(defaultSaveProjectTimerDelay, true);
+    timestampSaveTime(SAVE_PROJECT_TIMER_DELAY, true);
 
     // Save project reminder timer. Check every 60 seconds
     setInterval(checkLastSavedTime, 60000);
@@ -823,7 +876,11 @@ function showInfo(data) {
     }
 
     // Display the project name
-    $(".project-name").text(data['name']);
+    if (projectData.name.length > PROJECT_NAME_DISPLAY_MAX_LENGTH) {
+        $('.project-name').html(data['name'].substring(0,PROJECT_NAME_DISPLAY_MAX_LENGTH - 1) + '...');
+    } else {
+        $(".project-name").html(data['name']);
+    }
 
     // Does the current user own the project?
     if (!data['yours']) {
@@ -844,6 +901,7 @@ function showInfo(data) {
 
     // Set the prject icon to the correct board type
     $("#project-icon").html('<img src="' + cdnUrl + projectBoardIcon[data['board']] + '"/>');
+//    $(".project-icon").html('<img src="' + CDN_URL + projectBoardIcon[ data['board'] ] + '"/>');
 };
 
 
@@ -856,14 +914,14 @@ function saveProject() {
         var code = getXml();
         projectData['code'] = code;
 
-        $.post(baseUrl + 'rest/project/code', projectData, function (data) {
+        $.post(BASE_URL + 'rest/project/code', projectData, function (data) {
             var previousOwner = projectData['yours'];
             projectData = data;
             projectData['code'] = code; // Save code in projectdata to be able to verify if code has changed upon leave
 
             // If the current user doesn't own this project, a new one is created and the page is redirected to the new project.
             if (!previousOwner) {
-                window.location.href = baseUrl + 'projecteditor?id=' + data['id'];
+                window.location.href = BASE_URL + 'projecteditor?id=' + data['id'];
             }
         }).done(function () {
             // Save was successful, show green with checkmark
@@ -904,7 +962,7 @@ function saveProject() {
         });
 
         // Mark the time when saved, add 20 minutes to it.
-        timestampSaveTime(defaultSaveProjectTimerDelay, true);
+        timestampSaveTime(SAVE_PROJECT_TIMER_DELAY, true);
 
     } else {
 
@@ -928,13 +986,13 @@ function saveAsDialog() {
                 var code = getXml();
                 projectData['code'] = code;
                 projectData['name'] = value;
-                $.post(baseUrl + 'rest/project/code-as', projectData, function (data) {
+                $.post(BASE_URL + 'rest/project/code-as', projectData, function (data) {
                     var previousOwner = projectData['yours'];
                     projectData = data;
                     projectData['code'] = code; // Save code in projectdata to be able to verify if code has changed upon leave
                     utils.showMessage(Blockly.Msg.DIALOG_PROJECT_SAVED, Blockly.Msg.DIALOG_PROJECT_SAVED_TEXT);
                     // Reloading project with new id
-                    window.location.href = baseUrl + 'projecteditor?id=' + data['id'];
+                    window.location.href = BASE_URL + 'projecteditor?id=' + data['id'];
                 });
             }
         });
@@ -1265,7 +1323,6 @@ function uploadHandler(files) {
             if (uploadedXML !== '') {
                 uploadedXML = EmptyProjectCodeHeader + uploadedXML + '</xml>';
             }
-            ;
 
             // TODO: check to see if this is used when opened from the editor (and not the splash screen)
             // maybe projectData.code.length < 43??? i.e. empty project? instead of the URL parameter...
@@ -1504,11 +1561,11 @@ function uploadMergeCode(append) {
             });
             tmpv += '</variables>';
             // add everything back together
-            projectData['code'] = EmptyProjectCodeHeader + tmpv + projCode + newCode + '</xml>';
+            projectData['code'] = EMPTY_PROJECT_CODE_HEADER + tmpv + projCode + newCode + '</xml>';
         } else if (newCode.indexOf('<variables>') > -1 && projCode.indexOf('<variables>') === -1) {
-            projectData['code'] = EmptyProjectCodeHeader + newCode + projCode + '</xml>';
+            projectData['code'] = EMPTY_PROJECT_CODE_HEADER + newCode + projCode + '</xml>';
         } else {
-            projectData['code'] = EmptyProjectCodeHeader + projCode + newCode + '</xml>';
+            projectData['code'] = EMPTY_PROJECT_CODE_HEADER + projCode + newCode + '</xml>';
         }
 
         ClearBlocklyWorkspace();
@@ -1551,9 +1608,9 @@ function initToolbox(profileName) {
     const blocklyOptions = {
         toolbox: filterToolbox(profileName),
         trashcan: true,
-        media: cdnUrl + 'images/blockly/',
+        media: CDN_URL + 'images/blockly/',
         readOnly: (profileName === 'propcfile'),
-        //path: cdnUrl + 'blockly/',
+        //path: CDN_URL + 'blockly/',
         comments: false,
 
         // zoom defaults used here
@@ -1615,7 +1672,7 @@ function getXml() {
     }
 
     // Return the XML for a blank project if none is found.
-    return EmptyProjectCodeHeader + '</xml>';
+    return EMPTY_PROJECT_CODE_HEADER + '</xml>';
 }
 
 

--- a/src/modals.js
+++ b/src/modals.js
@@ -241,7 +241,7 @@ function CreateNewProject() {
     if (projectData && $('#new-project-dialog-title').html() === page_text_label['editor_edit-details']) {
         code = getXml();
     } else {
-        code = EmptyProjectCodeHeader;
+        code = EMPTY_PROJECT_CODE_HEADER;
     }
 
     // Save the form fields into the projectData object
@@ -296,7 +296,7 @@ function OpenProjectModal() {
         // A copy of the current project is located in the browser localStorage
         setupWorkspace(projectData,
             function () {
-                window.localStorage.removeItem(localProjectStoreName);
+                window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
             });
     });
 
@@ -304,9 +304,9 @@ function OpenProjectModal() {
     $('#open-project-select-file-open').on('click', () => {
         if (window.localStorage.getItem(tempProjectStoreName)) {
             window.localStorage.setItem(
-                localProjectStoreName,
-                window.localStorage.getItem(tempProjectStoreName));
-            window.localStorage.removeItem(tempProjectStoreName);
+                LOCAL_PROJECT_STORE_NAME,
+                window.localStorage.getItem(TEMP_PROJECT_STORE_NAME));
+            window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
             window.location = 'blocklyc.html';
         }
     });
@@ -315,7 +315,7 @@ function OpenProjectModal() {
     $('#open-project-dialog').modal({keyboard: false, backdrop: 'static'});
 
     // If the user selects a file and successfully uploads it, the
-    // project will be stored in localStorage.tempProjectStoreName.
+    // project will be stored in localStorage.TEMP_PROJECT_STORE_NAME.
     // The form Accept button handler should look there when it is
     // time to proces the new project.
 }
@@ -349,8 +349,8 @@ function OpenProjectFileDialog() {
     // TODO: what is this doing here? Shouldn't we be setting up projectData instead of localStore?
     //       Or can this simply be deleted, because the openFile functions will take care of this?
     if (projectData) {
-        console.log("Loading workspace with project %s", localProjectStoreName);
-        setupWorkspace(JSON.parse(window.localStorage.getItem(localProjectStoreName)));
+        console.log("Loading workspace with project %s", LOCAL_PROJECT_STORE_NAME);
+        setupWorkspace(JSON.parse(window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)));
     }
 }
 

--- a/src/style-editor.css
+++ b/src/style-editor.css
@@ -439,6 +439,31 @@ ul > hr {
     padding-right: 10px;
 }
 
+.project-name {
+    max-width: 250px;
+    text-overflow: clip;
+    overflow: hidden;
+    overflow-wrap: normal;
+    white-space: nowrap;
+    text-align: left;
+}
+
+.project-name:focus {
+    outline: none;
+}
+
+.project-name-editable {
+    border: 3px solid #00f;
+    border-radius: 5px;
+    padding: 0px 5px;
+    background-color: white;
+}
+
+.project-icon {
+    float: left; 
+    padding-right: 5px
+}
+
 .bp-client-available {
     background:none;
     border:1px solid rgba(0, 0, 0, 0);


### PR DESCRIPTION
This is an update to PR #120 to correct merge conflicts.

Makes the project name editable, and after editing, updates the projectData object with the new name.

Setting a default name, etc. can (and should be) be dealt with in issue #115.

To Test:
1.) click the project name in the top-right corner
2.) Make sure the styling changes (blue outline)
3.) edit/change the project name
4.) when you click elsewhere (de-focus the project name), the styling should return to normal.
5.) Choose "edit project details" in the hamburger menu to make sure the new project name persists.