### PR TITLE
Issue 106 supplemental update

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -866,6 +866,7 @@ function setupWorkspace(data, callback) {
  * @param data is the project data structure
  */
 function showInfo(data) {
+    // TODO: Remove this.
     if (getURLParameter('debug')) {
         console.log(data);
     }
@@ -878,6 +879,7 @@ function showInfo(data) {
     }
 
     // Does the current user own the project?
+    // TODO: There is no project-owner context in Solo.
     if (!data['yours']) {
         // If not, display owner username
         $(".project-owner").text("(" + data['user'] + ")");

--- a/src/style-editor.css
+++ b/src/style-editor.css
@@ -453,7 +453,7 @@ ul > hr {
 }
 
 .project-name-editable {
-    border: 3px solid #00f;
+    border: 1px solid #2b669a;
     border-radius: 5px;
     padding: 0px 5px;
     background-color: white;


### PR DESCRIPTION
Update the CSS to tone down the border surrounding the project name on the edit page when the user is editing the project name.

Added tasks to remove the concept of project owner. In Solo, the project owner is the individual who possess the project file. In BlocklyProp, project ownership is determined when the project is created and stored in the cloud infrastructure. 
