### PR TITLE
Modal dismissed with 'x' click invalidates editor canvas

### DIFF
--- a/src/modals.js
+++ b/src/modals.js
@@ -83,6 +83,8 @@ function showNewProjectModal() {
     NewProjectModalCancelClick();   // Handle a click on the Cancel button
     NewProjectModalAcceptClick();   // Handle a click on the Open button
     NewProjectModalEnterClick();    // Handle the user pressing the Enter key
+    NewProjectModalEscapeClick();   // Handle user clicking on the 'x' icon
+
 
     // let dialog = $("#new-project-board-type");
     PopulateProjectBoardTypesUIElement($("#new-project-board-type"));
@@ -175,7 +177,24 @@ function NewProjectModalCancelClick() {
     });
 }
 
+function NewProjectModalEscapeClick() {
+    /* Trap the modal event that fires when the modal window is
+ * closed when the user clicks on the 'x' icon.
+ */
+    $('#new-project-dialog').on('hidden.bs.modal', function (e) {
+        if (!projectData) {
+            // If there is no project, go to home page.
+            window.location.href = 'index.html';
+        }
+        // Reload the the editor canvas from the active copy of the
+        // project.
+        setupWorkspace(projectData,
+            function () {
+                window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
+            });
+    });
 
+}
 /**
  * Verify that the project name and board type form fields have data
  *

--- a/src/modals.js
+++ b/src/modals.js
@@ -311,6 +311,24 @@ function OpenProjectModal() {
         }
     });
 
+
+    /* Trap the modal event that fires when the modal window is
+     * closed when the user clicks on the 'x' icon.
+     */
+    $('#open-project-dialog').on('hidden.bs.modal', function (e) {
+        if (!projectData) {
+            // If there is no project, go to home page.
+            window.location.href = 'index.html';
+        }
+        // Reload the the editor canvas from the active copy of the
+        // project.
+        setupWorkspace(projectData,
+            function () {
+                window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
+            });
+    });
+
+
     // Import a project .SVG file
     $('#open-project-dialog').modal({keyboard: false, backdrop: 'static'});
 


### PR DESCRIPTION
Address issue #146.

The bootstrap modal dialog as implemented in Solo responds to the button clicks and to the event fired when the Enter key is pressed. There is also an anti-pattern when the 'X' button that dismisses the modal windows is clicked. This does not fire a 'click' event, but instead fires a 'hidden.bs.modal' event when the modal is closed as a result of the click detected on the 'X' icon in the modal.

 The PR adds code to detect the hidden.bs.modal event and attempts to reconstruct the existing project if there is one. Otherwise, it returns the user to the home page to start a new project or to load an existing project.
