### PR TITLE
Solo 111b Generate code for MYVALUE if not already defined

### DIFF
--- a/src/blockly/generators/propc/base.js
+++ b/src/blockly/generators/propc/base.js
@@ -814,6 +814,7 @@ Blockly.Blocks.string_var_length = {
                 .appendField('String variable set size of');
         this.optionList_ = ['var'];
         this.userDefinedConstantsList_ = ['MYVALUE'];
+        this.setMYVALUEconstantValue = false;
         this.updateConstMenu();
         this.updateShape_();
         this.setPreviousStatement(true, "Block");
@@ -960,18 +961,27 @@ Blockly.Blocks.string_var_length = {
         }
     },
     onchange: function () {
-        var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        var strVarBlocksCount = 0;
-        for (var x = 0; x < allBlocks.length; x++) {
-            if (allBlocks[x].type === 'string_var_length') {
-                strVarBlocksCount++;
+        this.setMYVALUEconstantValue = '';
+
+        var mainWorkspace = Blockly.getMainWorkspace();
+        var warnTxt = '';
+        if (mainWorkspace.getBlocksByType('string_var_length').length > 1) {
+            warnTxt += 'WARNING! Only use one of these blocks!';
+        }
+
+        var myDefineBlockWarning = '\n\nWARNING! MYVALUE is not defined!';
+        mainWorkspace.getBlocksByType('constant_define').forEach(function (theBlock) {
+            if (theBlock.getFieldValue('CONSTANT_NAME') === 'MYVALUE') {
+                myDefineBlockWarning = '';
             }
+        });
+        warnTxt += myDefineBlockWarning;
+
+        if (myDefineBlockWarning !== '') {
+            this.setMYVALUEconstantValue = true;
         }
-        if (strVarBlocksCount > 1) {
-            this.setWarningText('WARNING! Only use one of these blocks!');
-        } else {
-            this.setWarningText(null);
-        }
+
+        this.setWarningText(warnTxt === '' ? null : warnTxt.trim());
     }
 };
 
@@ -1009,6 +1019,10 @@ Blockly.Blocks.string_var_length_con = {
 };
 
 Blockly.propc.string_var_length = function () {
+    if (!this.disabled && this.setMYVALUEconstantValue) {
+        Blockly.propc.definitions_["USER_MYVALUE"] = '#define MY_MYVALUE\t64';
+    }
+
     var i = 0;
     Blockly.propc.string_var_lengths = [];
     while (this.getInput('VAR' + i.toString(10))) {


### PR DESCRIPTION
Addresses recent discussion from #111 

Does not address broader issues with the constant define blocks.  My opinion is that the remainder of the issues should be addressed as part of #175. 

To test:
 - Create a string var length block and mutate it to include a named constant.  The block should throw a warning.
 - To test code generation you'll have to assign a string to the item variable, but then check to see that the MYVALUE constant is defined to 64 (default value for string length).
 - Drag another string var length block out, check to see that the warning now contains warnings about both the extra block and undefined constant.
 - Delete the extra block, define MYVALUE, ensure the warning disappears.