### PR TITLE
Issue 183 project change detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                             <li><a onclick="showLicense()">License</a></li>
                             <li>
                                 <a href="http://www.parallax.com" target="_blank">
-                                v1.3.504 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
+                                v1.3.505 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
                             </li>
                         </ul>
                     </div>

--- a/src/editor.js
+++ b/src/editor.js
@@ -425,7 +425,6 @@ function checkLeave() {
     let currentXml = getXml();
     let savedXml = projectData['code'];
 
-    // return !(savedXml === currentXml);
     return compareProjectCode(currentXml, savedXml);
 }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -425,7 +425,44 @@ function checkLeave() {
     let currentXml = getXml();
     let savedXml = projectData['code'];
 
-    return !(savedXml === currentXml);
+    // return !(savedXml === currentXml);
+    return compareProjectCode(currentXml, savedXml);
+}
+
+
+/**
+ * Compare the project block code of two projects for equality
+ *
+ * @param projectA is one of the two projects to compare for equality
+ * @param projectB is the second of two projects to compare for equalityy.
+ *
+ * @returns {boolean} True if projects are unequal, otherwise return false
+ */
+function compareProjectCode(projectA, projectB) {
+    // Looking for the first <block> XML element
+    const searchTerm = '<block';
+
+    // Get the offset to the first <block> xml element
+    let indexA = projectA.indexOf(searchTerm);
+    let indexB = projectB.indexOf(searchTerm);
+
+    // No blocks in either copy of the project
+    // They must be equally devoid of a project
+    if (indexA === -1 && indexB === -1) {
+        return false;
+    }
+
+    // Return false if the first block is not found
+    // in one of the two projects.
+    if (indexA === -1 || indexB === -1) {
+        return true;
+    }
+
+    // Start comparing the projects beginning with the first block
+    // that appears after the namespace declaration
+    return findFirstDiffPos(
+        projectA.substring(indexA, projectA.length),
+        projectB.substring(indexB, projectB.length)) === -1;
 }
 
 
@@ -587,14 +624,11 @@ function initEventHandlers() {
     $('#btn-view-blocks').on('click', () => renderContent('tab_blocks'));
     $('#btn-view-xml').on('click', () => renderContent('tab_xml'));
 
-    // Blocks/Code/XML button
-    $('#btn-view-propc').on('click', () => renderContent('tab_propc'));
-    $('#btn-view-blocks').on('click', () => renderContent('tab_blocks'));
-    $('#btn-view-xml').on('click', () => renderContent('tab_xml'));
-        
+    // NEW Button
     // New Project toolbar button
     $('#new-project-button').on('click', () => NewProjectModal());
 
+    // OPEN Button
     // Open Project toolbar button
     $('#open-project-button').on('click', () => {
         // Save the project to localStorage

--- a/src/editor.js
+++ b/src/editor.js
@@ -460,9 +460,13 @@ function compareProjectCode(projectA, projectB) {
 
     // Start comparing the projects beginning with the first block
     // that appears after the namespace declaration
-    return findFirstDiffPos(
+    let result = findFirstDiffPos(
         projectA.substring(indexA, projectA.length),
-        projectB.substring(indexB, projectB.length)) === -1;
+        projectB.substring(indexB, projectB.length));
+
+    // findFirstDiffPos() will return a -1 if the projects are
+    // identical, that is, the project was not altered.
+    return result !== -1;
 }
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -217,3 +217,36 @@ navigator.browserSpecs = (function(){
         M.splice(1, 1, tem[1]);
     return {name:M[0], version:M[1], system:osName};
 })();
+
+
+/**
+ * Find offset to first unequal character in two strings.
+ * @param a
+ * @param b
+ *
+ * @returns {number}
+ * Returns the offset to first character in either string
+ * where the characters differ at that location.
+ *
+ * Returns the length of the shorter string if the strings are of
+ * differing lengths but are equal up to the end of the shorter
+ * string.
+ *
+ * Returns -1 if none of the above conditions are met.
+ *
+ * @description
+ * https://stackoverflow.com/questions/32858626/detect-position-of-first-difference-in-2-strings
+ *
+ */
+function findFirstDiffPos(a, b)
+{
+    let shorterLength = Math.min(a.length, b.length);
+
+    for (let i = 0; i < shorterLength; i++) {
+        if (a[i] !== b[i]) return i;
+    }
+
+    if (a.length !== b.length) return shorterLength;
+
+    return -1;
+}


### PR DESCRIPTION
Addresses issue #183 
The latest Blockly core uses a different XML namespace than previous versions. When project files created with older versions of the core are loaded, the XML namespace declaration in the projectData variable will not match the XML namespace provided from the call to getXML(). This causes the system to identify the current project as having been modified when, in fact, it has not.

This patch skirts the issue by locating the beginning of the actual project code and then begin the comparison from that point.

This patch also removes four redundant lines of code that were erroneously  inserted in a previous PR. 