### PR TITLE
Patch 191128a

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -313,14 +313,6 @@
                                 </a>
                             </li>
 
-                            <!-- Download blocks file
-                            <li>
-                                <a id="download-project" href="#">
-                                    <span class="keyed-lang-string" data-key="editor_download"></span>
-                                </a>
-                            </li>
-                            -->
-
                             <li class="auth-true" data-displayas="list-item">
                                 <a id="upload-project">
                                     <span class="keyed-lang-string" data-key="editor_upload"></span>
@@ -370,6 +362,7 @@
         </div>
     </div>
 
+    <!-- Possible one of two -->
     <!-- Save or Upload a project file -->
     <div class="modal fade" id="upload-dialog">
         <div class="modal-dialog">

--- a/blocklyc.html
+++ b/blocklyc.html
@@ -289,14 +289,6 @@
                                 </a>
                             </li>
 
-                            <!-- New Project menu item
-                            <li class="auth-true offline-only hidden" data-displayas="list-item">
-                                <a id="new-project-menu-item" href="#" class="url-prefix">
-                                    <span class="keyed-lang-string" data-key="menu_newproject_title"></span>
-                                </a>
-                            </li>
-                            -->
-
                             <li class="online-only divider"></li>
 
                             <li>

--- a/src/editor.js
+++ b/src/editor.js
@@ -108,16 +108,6 @@ var last_saved_time = 0;
 
 
 /**
- * The primary key for the project (online version)
- *
- * @type {number}
- * @deprecated
- *  Solo does not have a concept of unique project identifiers.
- */
-var idProject = 0;
-
-
-/**
  * Uploaded project XML code
  *
  * @type {string}
@@ -340,8 +330,6 @@ $(() => {
 
     initCdnImageUrls();
     initClientDownloadLinks();
-
-    idProject = getURLParameter('project');
 
     // TODO: Use the ping endpoint to verify that we are offline.
 
@@ -1201,7 +1189,7 @@ function downloadCode() {
         SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,-83)" style="font-weight:bold;">Parallax BlocklyProp Project</text>';
         SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,-68)">User: ' + encodeToValidXml(projectData['user']) + '</text>';
         SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,-53)">Title: ' + encodeToValidXml(projectData['name']) + '</text>';
-        SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,-38)">Project ID: ' + idProject + '</text>';
+        SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,-38)">Project ID: 0</text>';
         SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,-23)">Device: ' + projectData['board'] + '</text>';
         SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,-8)">Description: ' + encodeToValidXml(projectData['description']) + '</text>';
         SVGfooter += '<text class="bkginfo" x="100%" y="100%" transform="translate(-225,13)" data-createdon="' + projectData['created'] + '" data-lastmodified="' + dt + '"></text>';

--- a/src/editor.js
+++ b/src/editor.js
@@ -90,8 +90,34 @@ const PROJECT_NAME_MAX_LENGTH = 100;
  */
 const PROJECT_NAME_DISPLAY_MAX_LENGTH = 20;
 
+/**
+ * The name used to store a project that is being loaded from
+ * offline storage.
+ *
+ * temp... is used to persist the imported SVG file. This file is a
+ * candidate until the user selects the 'Open' button to confirm that
+ * this file is the one to be loaded into the app.
+ *
+ * local... is used as the project that will either replace the
+ * current project or be appended to the current project.
+ *
+ * @type {string}
+ */
+const TEMP_PROJECT_STORE_NAME = "tempProject";
+const LOCAL_PROJECT_STORE_NAME = 'localProject';
 
 /**
+ * The default number of minutes to wait until the user is prompted
+ * to save the altered project.
+ *
+ * @type {number}
+ */
+const SAVE_PROJECT_TIMER_DELAY = 20;
+
+
+/**
+ *  Timestamp to indicate the amount of time that must expire before
+ *  the user is advised to save their project.
  *
  * @type {number}
  */
@@ -99,8 +125,8 @@ var last_saved_timestamp = 0;
 
 
 /**
- * Timestamp to record when the current project was last saved to
- * storage
+ * Timestamp to record the amount of time that has gone by since the
+ * current project was last saved to storage.
  *
  * @type {number}
  */
@@ -144,35 +170,11 @@ var bpIcons = {
 
 
 /**
- * The name used to store a project that is being loaded from
- * offline storage.
- *
- * temp... is used to persist the imported SVG file. This file is a
- * candidate until the user selects the 'Open' button to confirm that
- * this file is the one to be loaded into the app.
- *
- * local... is used as the project that will either replace the
- * current project or be appended to the current project.
- *
- * @type {string}
- */
-const TEMP_PROJECT_STORE_NAME = "tempProject";
-const LOCAL_PROJECT_STORE_NAME = 'localProject';
-
-
-/**
  * This is the object returned from the call to Blockly.inject()
  */
 var blocklyWorkSpace;
 
 
-/**
- * The default number of minutes to wait until the user is prompted
- * to save the altered project.
- *
- * @type {number}
- */
-const SAVE_PROJECT_TIMER_DELAY = 20;
 
 
 // TODO: set up a markdown editor (removed because it doesn't work in a Bootstrap modal...)
@@ -336,10 +338,6 @@ $(() => {
     // Stop pinging the Rest API
     clearInterval(pingInterval);
 
-    // hide save interaction elements
-    $('.online-only').addClass('hidden');
-    $('.offline-only').removeClass('hidden');
-
     // Load a project file from local storage
     if (getURLParameter('openFile') === "true") {
         // Check for an existing project in localStorage
@@ -353,6 +351,7 @@ $(() => {
 
     } else if (getURLParameter('newProject') === "true") {
         NewProjectModal();
+
     } else if (window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)) {
         // Load a project from localStorage if available
         try {

--- a/src/editor.js
+++ b/src/editor.js
@@ -906,7 +906,7 @@ function showInfo(data) {
 
 
 /**
- *
+ * @deprecated Cannot find any references to this function in code.
  */
 function saveProject() {
     // TODO: Refactor to remove the concept of project ownership

--- a/src/editor.js
+++ b/src/editor.js
@@ -642,7 +642,9 @@ function initEventHandlers() {
         window.location = "blocklyc.html?openFile=true";
     });
 
-    // Save Project button goes here!
+    // Save button
+    // Save Project modal 'Save' button click handler
+    $('#save-btn, #save-project').on('click', () => downloadCode());
 
 
     // --------------------------------
@@ -661,7 +663,7 @@ function initEventHandlers() {
     $('#download-side').on('click', () => downloadPropC());
 
     /**
-     * Import project file
+     * Import project file menu selector
      *
      * @description
      * Import (upload) project from storage. This is designed to
@@ -671,34 +673,36 @@ function initEventHandlers() {
 
     // ---- Hamburger drop down horizontal line ----
 
-    // Still looking for these buttons in the UI
+    // Configure client menu selector
     $('#client-setup').on('click', () => configure_client());
 
+    // --------------------------------
+    // End of hamburger menu items
+    // --------------------------------
 
-    // **  End of Drop-down menu
-    // **************************************************************
 
+    // Save As button
+    $('#save-as-btn').on('click', () => saveAsDialog());
+    // Save-As Project
+    $('#save-project-as').on('click', () => saveAsDialog());
+
+    // Save As new board type
+    $('#save-as-board-type').on('change', () => checkBoardType(
+        $('#saveAsDialogSender').html()));
+    $('#save-as-board-btn').on('click', () => saveProjectAs(
+        $('#save-as-board-type').val(),
+        $('#save-as-project-name').val()
+    ));
 
     $('#selectfile-clear').on('click', () => clearUploadInfo(true));
-    $('#save-as-btn').on('click', () => saveAsDialog());
-
-
-    // Save Project modal 'Save' button click handler
-    $('#save-btn, #save-project').on('click', () => downloadCode());
-
 
     $('#btn-graph-play').on('click', () => graph_play());
     $('#btn-graph-snapshot').on('click', () => downloadGraph());
     $('#btn-graph-csv').on('click', () => downloadCSV());
     $('#btn-graph-clear').on('click', () => graphStartStop('clear'));
 
-    $('#save-as-board-type').on('change', () => checkBoardType($('#saveAsDialogSender').html()));
 
-    $('#save-as-board-btn').on('click', () => saveProjectAs(
-        $('#save-as-board-type').val(),
-        $('#save-as-project-name').val()
-    ));
-
+    // Client install instruction modals
     $('#win1-btn').on('click', () => showStep('win', 1, 3));
     $('#win2-btn').on('click', () => showStep('win', 2, 3));
     $('#win3-btn').on('click', () => showStep('win', 3, 3));
@@ -715,8 +719,6 @@ function initEventHandlers() {
     $('.show-os-chr').on('click', () => showOS('ChromeOS'));
     $('.show-os-lnx').on('click', () => showOS('Linux'));
 
-    // Save-As Project
-    $('#save-project-as').on('click', () => saveAsDialog());
 
     // --------------------------------------------------------------
     // Bootstrap modal event handler for the Save Project Timer

--- a/src/editor.js
+++ b/src/editor.js
@@ -359,7 +359,10 @@ $(() => {
             // put a copy into projectData
             projectData = JSON.parse(window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME));
         }
+
+        // Show the Open Project modal dialog
         OpenProjectModal();
+
     } else if (getURLParameter('newProject') === "true") {
         NewProjectModal();
     } else if (window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)) {
@@ -664,13 +667,6 @@ function initEventHandlers() {
     $('#download-side').on('click', () => downloadPropC());
 
     /**
-     * Download project to disk
-     * @deprecated
-     */
-    $('#download-project').on('click', () => downloadCode());
-
-
-    /**
      * Import (upload) project from storage
      * @description This is designed to merge code from an existing
      * project into the current project.
@@ -838,15 +834,6 @@ function setupWorkspace(data, callback) {
 
     projectData = data;
     showInfo(data);         // Update the UI with project related details
-
-    // --------------------------------------------------------------
-    // Set the global project ID. in the offline mode, the project
-    // id is set to 0 when the project is loaded from local storage.
-    // --------------------------------------------------------------
-    // TODO: Remove this code
-    if (!idProject) {
-        idProject = projectData['id'];
-    }
 
     // Set various project settings based on the project board type
     // NOTE: This function is in propc.js

--- a/src/editor.js
+++ b/src/editor.js
@@ -645,18 +645,12 @@ function initEventHandlers() {
     // Save Project button goes here!
 
 
+    // --------------------------------
     // Hamburger menu items
-    //    $('#selectfile-replace').on('click',    function () {  uploadMergeCode(false); });
-    //    $('#selectfile-append').on('click',     function () {  uploadMergeCode(true); });
+    // --------------------------------
 
     // Edit project details
     $('#edit-project-details').on('click', () => editProjectDetails());
-
-    // New Project - Load a new project menu click handler
-    /**
-     * @deprecated
-     */
-    $('#new-project-menu-item').on('click', () => NewProjectModal());
 
     // Help and Reference - online help web pages
     // Implemented as an href in the menu
@@ -667,9 +661,11 @@ function initEventHandlers() {
     $('#download-side').on('click', () => downloadPropC());
 
     /**
-     * Import (upload) project from storage
-     * @description This is designed to merge code from an existing
-     * project into the current project.
+     * Import project file
+     *
+     * @description
+     * Import (upload) project from storage. This is designed to
+     * merge code from an existing project into the current project.
      */
     $('#upload-project').on('click', () => uploadCode());
 

--- a/src/modals.js
+++ b/src/modals.js
@@ -35,6 +35,7 @@
 
 
 /**
+ * Start the process to open a new project
  *
  * @description
  *
@@ -49,11 +50,15 @@ function NewProjectModal() {
             'The current project has been modified. Click OK to\n' +
             'discard the current changes and create a new project.';
 
-        utils.confirm("Save Project", message, (result) => {
-            if (result) {
-                downloadCode();
-            }
-        }, "OK", "Cancel");
+        utils.confirm(
+            "Save Project", message,
+            // result is true if the OK button was selected
+            (result) => {
+                if (result) {
+                    downloadCode();
+                }},
+            "OK",
+            "Cancel");
     } else {
         // Reset the values in the form to defaults
         $('#new-project-name').val('');
@@ -177,6 +182,13 @@ function NewProjectModalCancelClick() {
     });
 }
 
+
+/**
+ * New project modal 'x' click handler
+ *
+ * This is fired when the user clicks on the 'x' to dismiss
+ * the dialog.
+ */
 function NewProjectModalEscapeClick() {
     /* Trap the modal event that fires when the modal window is
  * closed when the user clicks on the 'x' icon.
@@ -292,12 +304,67 @@ function CreateNewProject() {
 
 /**
  *  Open the modal to select a project file to load
+ *
+ *  @description
+ *  If the user selects a file and successfully uploads it, the
+ *  project will be stored in localStorage.TEMP_PROJECT_STORE_NAME.
+ *  The form Accept button handler should look there when it is
+ *  time to process the new project.
  */
 function OpenProjectModal() {
 
     // set title to Open file
     $('#open-project-dialog-title').html(page_text_label['editor_open']);
 
+    OpenProjectModalCancelClick();
+    OpenProjectModalOpenClick();
+    OpenProjectModalEscapeClick();
+
+    // Import a project .SVG file
+    $('#open-project-dialog').modal({keyboard: false, backdrop: 'static'});
+}
+
+
+/**
+ * Connect an event handler to the 'Open' button in the Open
+ * Project modal dialog.
+ *
+ * @description
+ * When a project is selected, the code responsible for retrieving
+ * project from disk will store it in the browser's localStorage
+ * under the key value TEMP_PROJECT_STORE_NAME. That same code will
+ * return control to the Open Project modal, where the user can
+ * select Open or Cancel.
+ *
+ * This event handler is invoked when the user selects the Open
+ * button. It looks for a project in the browser's local
+ * storage with a key value of TEMP_PROJECT_STORE_NAME. If one is
+ * found, it simply copies the project to a new key in the browser's
+ * local storage with the key LOCAL_PROJECT_STORE_NAME and removes
+ * the temporary copy stored in TEMP_PROJECT_STORE_NAME. It then
+ * redirects the browser to the editor page, where other code will
+ * look for a project in the browser's local storage under the
+ * LOCAL_PROJECT_STORE_NAME key and load it into the editor canvas
+ * if a project is found there.
+ */
+function OpenProjectModalOpenClick() {
+    $('#open-project-select-file-open').on('click', () => {
+        if (window.localStorage.getItem(TEMP_PROJECT_STORE_NAME)) {
+            window.localStorage.setItem(
+                LOCAL_PROJECT_STORE_NAME,
+                window.localStorage.getItem(TEMP_PROJECT_STORE_NAME));
+
+            window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
+            window.location = 'blocklyc.html';
+        }
+    });
+}
+
+
+/**
+ * Open project cancel button clicked event handler
+ */
+function OpenProjectModalCancelClick() {
     // Set button onClick event handlers
     // ----------------------------------------------------------
     // This is also handling the 'Edit Project Details' modal
@@ -318,19 +385,13 @@ function OpenProjectModal() {
                 window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
             });
     });
+}
 
 
-    $('#open-project-select-file-open').on('click', () => {
-        if (window.localStorage.getItem(TEMP_PROJECT_STORE_NAME)) {
-            window.localStorage.setItem(
-                LOCAL_PROJECT_STORE_NAME,
-                window.localStorage.getItem(TEMP_PROJECT_STORE_NAME));
-            window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
-            window.location = 'blocklyc.html';
-        }
-    });
-
-
+/**
+ * Open project escape ('x') click event handler
+ */
+function OpenProjectModalEscapeClick() {
     /* Trap the modal event that fires when the modal window is
      * closed when the user clicks on the 'x' icon.
      */
@@ -346,16 +407,10 @@ function OpenProjectModal() {
                 window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
             });
     });
-
-
-    // Import a project .SVG file
-    $('#open-project-dialog').modal({keyboard: false, backdrop: 'static'});
-
-    // If the user selects a file and successfully uploads it, the
-    // project will be stored in localStorage.TEMP_PROJECT_STORE_NAME.
-    // The form Accept button handler should look there when it is
-    // time to proces the new project.
 }
+
+
+
 
 /**
  *  Open the Open Project File dialog


### PR DESCRIPTION
Refactor Open Project dialog event handlers.
Remove deprecated 'Download' event handler support.
Removed deprecated new project from hamburger menu.
Move menu item event handlers to map the hamburger menu.
Remove deprecated idProject global.
Remove unused on-line, off-line element references.
Deprecating the SaveProject function as orphaned code.
