### PR TITLE
Solo 195 Fix dropdown change handler

### DIFF
--- a/src/blockly/generators/propc/communicate.js
+++ b/src/blockly/generators/propc/communicate.js
@@ -966,14 +966,19 @@ Blockly.Blocks.serial_open = {
         }
     },
     mutationToDom: function () {
+        var container;
         if (this.otherBaud || this.otherMode) {
-            var container = document.createElement('mutation');
+            container = document.createElement('mutation');
+        }
+        if (this.otherBaud) {
             container.setAttribute('baud', this.getFieldValue('BAUD') || '1200');
+        }
+        if (this.otherMode) {
             for (var k = 0; k < 4; k++) {
                 container.setAttribute('ck_bit' + k.toString(10), this.getFieldValue('ck_bit' + k.toString(10)) || 'FALSE');
             }
-            return container;
         }
+        return container;
     },
     domToMutation: function (xmlElement) {
         var br = xmlElement.getAttribute('baud');

--- a/src/blockly/generators/propc/communicate.js
+++ b/src/blockly/generators/propc/communicate.js
@@ -896,8 +896,8 @@ Blockly.Blocks.serial_open = {
                 .appendField(new Blockly.FieldDropdown([
                     ["standard", "standard"],
                     ["other", "other"]
-                ], function () {
-                    this.sourceBlock_.setToMode();
+                ], function (value) {
+                    this.sourceBlock_.setToMode(value);
                 }), "TYPE");
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
@@ -946,22 +946,24 @@ Blockly.Blocks.serial_open = {
         }
     },
     setToMode: function (details) {
-        if (!details) {
-            var details = ['FALSE', 'FALSE', 'FALSE', 'FALSE'];
+        if (details === 'other') {
+            details = ['FALSE', 'FALSE', 'FALSE', 'FALSE'];
         }
-        if(this.getInput('MODE')) {
-            this.removeInput('MODE');
+        if (details !== 'standard') {
+            if(this.getInput('MODE')) {
+                this.removeInput('MODE');
+            }
+            this.appendDummyInput('MODE')
+                    .appendField("invert RX")
+                    .appendField(new Blockly.FieldCheckbox(details[0]), "ck_bit0")
+                    .appendField("invert TX")
+                    .appendField(new Blockly.FieldCheckbox(details[1]), "ck_bit1")
+                    .appendField("open-drain")
+                    .appendField(new Blockly.FieldCheckbox(details[2]), "ck_bit2")
+                    .appendField("remove TX echo")
+                    .appendField(new Blockly.FieldCheckbox(details[3]), "ck_bit3");
+            this.otherMode = true;
         }
-        this.appendDummyInput('MODE')
-                .appendField("invert RX")
-                .appendField(new Blockly.FieldCheckbox(details[0]), "ck_bit0")
-                .appendField("invert TX")
-                .appendField(new Blockly.FieldCheckbox(details[1]), "ck_bit1")
-                .appendField("open-drain")
-                .appendField(new Blockly.FieldCheckbox(details[2]), "ck_bit2")
-                .appendField("remove TX echo")
-                .appendField(new Blockly.FieldCheckbox(details[3]), "ck_bit3");
-        this.otherMode = true;
     },
     mutationToDom: function () {
         if (this.otherBaud || this.otherMode) {


### PR DESCRIPTION
Addresses #195 

Dropdown change handler was missing an argument and behaving badly because it now gets fired when blocks are dragged out of the toolbox.
This provides a value in the change handler and uses that value in the domToMutation for the block.  This also separates the two mutations - before, if one type of mutation was set, reloading the block would load them both.  Now only the set mutations are loaded.

To test: drag out Communicate > Protocols > Serial Initialize from the toolbox.  If it doesn't freeze up and generates working code, the bug is fixed.