### PR TITLE
Marked the configure_client function as deprecated.

### DIFF
--- a/src/blocklypropclient.js
+++ b/src/blocklypropclient.js
@@ -283,28 +283,46 @@ var connection_heartbeat = function () {
     }
 };
 
+/**
+ * @deprecated - This function will become obsolete when the
+ * BlocklyProp Client is deprecated and removed from service.
+ */
 var configure_client = function () {
-    var url_input = $("<form/>", {
+    // All of this code is building the UI for the Configure
+    // BlocklyProp Client dialog.
+    let url_input = $("<form/>", {
         class: "form-inline"
     });
+
+    // This is hard-coding the HTTP protocol for the BlocklyProp Client
     $("<span/>", {
         class: "space_right"
     }).text("http://").appendTo(url_input);
-    var domain_name_group = $("<div/>", {
+
+    // Add the form group to the DOM for the input field defined next
+    let domain_name_group = $("<div/>", {
         class: "form-group"
     }).appendTo(url_input);
+
+    // Default the domain input box
     $("<input/>", {
         id: "domain_name",
         type: "text",
         class: "form-control",
         value: client_domain_name
     }).appendTo(domain_name_group);
+
+    // Hard code the ':' between the domain name and port input fields
     $("<span/>", {
         class: "space_left space_right"
     }).text(":").appendTo(url_input);
-    var domain_port_group = $("<div/>", {
+
+    // Add the form group to the DOM for the next input field
+    let domain_port_group = $("<div/>", {
         class: "form-group"
     }).appendTo(url_input);
+
+    // Get the port number
     $("<input/>", {
         id: "port_number",
         type: "number",
@@ -312,6 +330,7 @@ var configure_client = function () {
         value: client_domain_port
     }).appendTo(domain_port_group);
 
+    // Show the modal dialog
     bootbox.dialog({
         title: "Configure BlocklyPropClient",
         message: url_input,

--- a/src/editor.js
+++ b/src/editor.js
@@ -665,6 +665,10 @@ function initEventHandlers() {
     // ---- Hamburger drop down horizontal line ----
 
     // Configure client menu selector
+    // Client configuration is only possible with the deprecated
+    // BlocklyProp Client. The BlocklyProp Launcher does not require
+    // a configuration dialog
+    // TODO: Client configuration is deprecated. No needed for Launcher
     $('#client-setup').on('click', () => configure_client());
 
     // --------------------------------


### PR DESCRIPTION
Addresses issue #203 
This is not needed with the new BP Launcher. Updated code comments to document what the code is doing with the UI. 
