### PR TITLE
Clean up lint warnings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-/src/lib/*
+src/lib/*

--- a/src/blockly/generators/propcToolbox.js
+++ b/src/blockly/generators/propcToolbox.js
@@ -1727,6 +1727,13 @@ var colorChanges = {
     '340': '#111111'
 };
 
+
+/**
+ * Filter the blocks available in the toolbox.
+ *
+ * @param {string} profileName
+ * @returns {string}
+ */
 function filterToolbox(profileName) {
 
     // Set the category's label (internationalization)
@@ -1742,14 +1749,14 @@ function filterToolbox(profileName) {
     }
 
     // Convert the xmlToolBox string to an XML object
-    parser = new DOMParser();
-    xmlDoc = parser.parseFromString(xmlToolbox, "text/xml");
+    let parser = new DOMParser();
+    let xmlDoc = parser.parseFromString(xmlToolbox, "text/xml");
 
     // Loop through the specified tags and filter based on their attributes
-    tagSearch = ['category', 'sep', 'block'];
+    let tagSearch = ['category', 'sep', 'block'];
 
-    // Toolbnox entries to be removed from the menu
-    var toRemove = [];
+    // Toolbox entries to be removed from the menu
+    let toRemove = [];
 
     //Scan the toolBox XML document for each search tag
     for (var j = 0; j < tagSearch.length; j++) {
@@ -1801,8 +1808,8 @@ function filterToolbox(profileName) {
     }
 
     // Turn the XML object back into a string
-    out = new XMLSerializer();
-    var outStr = out.serializeToString(xmlDoc);
+    let out = new XMLSerializer();
+    let outStr = out.serializeToString(xmlDoc);
     outStr = outStr.replace(/ include="[\S]+"/g, '').replace(/ exclude="[\S]+"/g, '');
 
     return outStr;

--- a/src/editor.js
+++ b/src/editor.js
@@ -870,7 +870,7 @@ function setupWorkspace(data, callback) {
     // Set the help link to the ab-blocks, s3 reference, or propc reference
     // TODO: modify blocklyc.html/jsp and use an id or class selector
     if (projectData.board === 's3') {
-        initToolbox(projectData.board, []);
+        initToolbox(projectData.board);
         $('#online-help').attr('href', 'https://learn.parallax.com/s3-blocks');
         // Create UI block content from project details
         renderContent('blocks');
@@ -880,7 +880,7 @@ function setupWorkspace(data, callback) {
         // Create UI block content from project details
         renderContent('propc');
     } else {
-        initToolbox(projectData.board, []);
+        initToolbox(projectData.board);
         $('#online-help').attr('href', 'https://learn.parallax.com/ab-blocks');
         // Create UI block content from project details
         renderContent('blocks');
@@ -1598,7 +1598,7 @@ function uploadMergeCode(append) {
 
 /**
  *
- * @param profileName - aka Board Type
+ * @param {string} profileName - aka Board Type
  */
 function initToolbox(profileName) {
 


### PR DESCRIPTION
Correct a number of warnings where variables were used before being declared in filterToolBox().

initToolBox() Does not have two parameters. Removed the second parameter, an empty array. 
Added type declarations to clean up variable type warnings.

.eslintignore should be ignore src/lib*, not /src/lib/*
