### PR TITLE
DO NOT PULL - Solo 200d simplify client heartbeat functions - holding as a reference

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -142,14 +142,7 @@
                 <!-- BlocklyProp Client or Loader UI -->
                 <div id="client-status-alerts" style="float: left;">
                     <span class="auth-true" style="padding-left: 10px; line-height: 30px;">
-                        <span id="client-searching" class="bp-client-warning">
-                            <a class="client-searching-link" data-toggle="modal" data-target="#client-download-modal"
-                                href="#">
-                                <span class="bpIcon" data-icon="warningCircle">!</span>
-                                <span class="keyed-lang-string" data-key="editor_client_checking"></span>
-                            </a>
-                        </span>
-                        <span id="client-unavailable" class="bp-client-danger hidden">
+                        <span id="client-unavailable" class="bp-client-danger">
                             <a class="client-unavailable-link" data-toggle="modal" data-target="#client-download-modal"
                                 href="#">
                                 <span class="bpIcon" data-icon="dangerTriangle">!!</span>
@@ -185,24 +178,24 @@
                     </a>
 
                     <!-- Load to RAM -->
-                    <a id="prop-btn-ram" class="btn btn-success btn-circle disabled auth-true" title=""
+                    <a id="prop-btn-ram" class="btn btn-success btn-circle disabled auth-true client-action no-s3" title=""
                     data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
                         <span class="bpIcon" data-icon="downArrowWhite"></span>
                     </a>
 
                     <!-- Load to EEPROM -->
-                    <a id="prop-btn-eeprom" class="btn btn-success btn-circle disabled auth-true" title=""
+                    <a id="prop-btn-eeprom" class="btn btn-success btn-circle disabled auth-true client-action" title=""
                     data-toggle="tooltip" data-placement="bottom" data-displayas="inline-block">
                         <span class="bpIcon" data-icon="downArrowBoxWhite">&gt;&gt;</span></a>
 
                     <!-- Open a terminal -->
-                    <a id="prop-btn-term" class="btn btn-primary btn-circle disabled auth-true" title=""
+                    <a id="prop-btn-term" class="btn btn-primary btn-circle disabled auth-true client-action" title=""
                     data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
                         <span class="bpIcon" data-icon="terminalWhite">#</span>
                     </a>
 
                     <!-- Open a graphing window -->
-                    <a id="prop-btn-graph" class="btn btn-primary btn-circle disabled auth-true" title=""
+                    <a id="prop-btn-graph" class="btn btn-primary btn-circle disabled auth-true client-action no-s3" title=""
                     data-toggle="tooltip"  data-placement="bottom" data-displayas="inline-block">
                         <span class="bpIcon" data-icon="graphWhite">~</span>
                     </a>

--- a/blocklyc.html
+++ b/blocklyc.html
@@ -479,7 +479,7 @@
                         data-key="editor_title_terminal">&nbsp;</h4>
                 </div>
                 <div class="modal-body">
-                    <div id="serial-conn-info"></div>
+                    <div class="connection-string"></div>
                     <div id="serial_console" class="prop-term"></div>
                 </div>
                 <div class="modal-footer">
@@ -500,7 +500,7 @@
                         data-key="editor_title_graphing">&nbsp;</h4>
                 </div>
                 <div class="modal-body" style="height: 445px;">
-                    <div id="graph-conn-info"></div>
+                    <div class="connection-string"></div>
                     <table>
                         <tr>
                             <td>

--- a/src/blockly/generators/propc.js
+++ b/src/blockly/generators/propc.js
@@ -222,7 +222,7 @@ function setProfile(profileName) {
     }
 
     // Setting a default baud rate
-    window.parent.setBaudrate(profile["default"]["baudrate"]);
+    baudrate = profile["default"]["baudrate"];
 }
 
 /**

--- a/src/blockly/language/en/messages.js
+++ b/src/blockly/language/en/messages.js
@@ -63,9 +63,10 @@ Blockly.Msg.DIALOG_SIDE_FILES_ERROR = 'A problem occurred when trying to create 
 Blockly.Msg.DIALOG_NO_CLIENT = '<i class="glyphicon glyphicon-exclamation-sign"></i> BlocklyPropClient <strong>is not running</strong>';
 Blockly.Msg.DIALOG_NO_DEVICE_TEXT = 'Ensure it is connected, powered on, and selected in the ports list. Make sure your BlocklyPropClient is up-to-date.';
 Blockly.Msg.DIALOG_DEVICE_COMM_ERROR_TEXT = 'BlocklyProp-Client not available to communicate with a microcontroller. It may help to "Force Refresh" by pressing Control-Shift-R (Windows/Linux) or Command-Shift-R (Mac).';
-Blockly.Msg.DIALOG_NO_DEVICE = 'No device detected';
+Blockly.Msg.DIALOG_NO_DEVICE = 'No devices found';
 Blockly.Msg.DIALOG_DEVICE_COMM_ERROR = 'Device communication error';
 Blockly.Msg.DIALOG_CLIENT_SEARCHING = '<i class="glyphicon glyphicon-info-sign"></i> Looking for BlocklyPropClient';
+Blockly.Msg.DIALOG_PORT_SEARCHING = 'Searching...';
 Blockly.Msg.DIALOG_DOWNLOAD = 'Download Project - Filename:';
 Blockly.Msg.DIALOG_UNSAVED_PROJECT = 'Unsaved Project';
 Blockly.Msg.DIALOG_EMPTY_PROJECT = 'Empty Project';
@@ -75,6 +76,7 @@ Blockly.Msg.DIALOG_SAVE_BEFORE_ADD_BLOCKS = 'You must save your project before y
 Blockly.Msg.DIALOG_MISSING_BLOCKS = 'Blocks missing';
 Blockly.Msg.DIALOG_MISSING_BLOCKS_GRAPHING = 'To use the graphing feature, your program must have both a graph initialize block and a graph value block.';
 Blockly.Msg.DIALOG_TERMINAL_NO_DEVICES_TO_CONNECT = 'Simulated terminal because there are no devices available to connect to';
+Blockly.Msg.DIALOG_GRAPH_NO_DEVICES_TO_CONNECT = 'Simulated graph because there are no devices available to connect to';
 Blockly.Msg.DIALOG_TERMINAL_NO_DEVICES = 'No connection established.';
 Blockly.Msg.DIALOG_TERMINAL_CONNECTION_ESTABLISHED = 'Connection established with';
 Blockly.Msg.DIALOG_TERMINAL_AT_BAUDRATE = 'at baudrate';

--- a/src/blocklyc.js
+++ b/src/blocklyc.js
@@ -684,7 +684,7 @@ function serial_console() {
     var newTerminal = false;
 
     // HTTP client
-    if (clientService.type !== 'ws') {
+    if (clientService.type === 'http') {
         if (term === null) {
             term = {
                 portPath: getComPort()
@@ -740,7 +740,6 @@ function serial_console() {
             });
         } else {
             clientService.activeConnection = null;
-            clientService.type = null;
 
             if (newTerminal) {
                 displayTerminalConnectionStatus(Blockly.Msg.DIALOG_TERMINAL_NO_DEVICES_TO_CONNECT);
@@ -748,6 +747,7 @@ function serial_console() {
             }
 
             $('#console-dialog').on('hidden.bs.modal', function () {
+                displayTerminalConnectionStatus(null);
                 pTerm.display(null);
                 term = null;
             });
@@ -768,7 +768,6 @@ function serial_console() {
             action: 'open'
         };
 
-        clientService.type = 'websocket';
         displayTerminalConnectionStatus([
             Blockly.Msg.DIALOG_TERMINAL_CONNECTION_ESTABLISHED,
             msg_to_send.portPath,
@@ -780,11 +779,11 @@ function serial_console() {
         $('#console-dialog').on('hidden.bs.modal', function () {
             if (msg_to_send.action !== 'close') { // because this is getting called multiple times...?
                 msg_to_send.action = 'close';
-                clientService.type = null;
                 displayTerminalConnectionStatus(null);
                 clientService.activeConnection.send(JSON.stringify(msg_to_send));
             }
             pTerm.display(null);
+            term = null;
         });
     }
 
@@ -874,7 +873,7 @@ function graphing_console() {
             graph.update(graph_data, graph_options);
         }
 
-        if (clientService.type !== 'ws' && clientService.portsAvailable) {
+        if (clientService.type === 'http' && clientService.portsAvailable) {
             var connection = new WebSocket(clientService.url('ws') + 'serial.connect');
 
             // When the connection is open, open com port
@@ -1019,7 +1018,7 @@ var graphStartStop = function (action) {
  * differently inside of blocklypropclient.js
  */
 var check_com_ports = function () {
-    if (clientService.type !== 'ws') {
+    if (clientService.type === 'http') {
         $.get(clientService.url('http') + 'ports.json', function (data) {
             set_port_list(data);
         }).fail(function () {

--- a/src/blocklypropclient.js
+++ b/src/blocklypropclient.js
@@ -188,7 +188,10 @@ function checkClientVersionModal() {
 }
 
 /**
- * This is evaluating the BlocklyProp Client or BlocklyProp Launcher version??
+ * This attempts to connect to an http client (BP-Client) only after
+ * an attempted connection to the BP-Launcher has failed.
+ * If both attempts have failed, it sets the client availablility to null
+ * and sets an interval to continue checking for a client.
  */
 var check_client = function () {
     $.get(clientService.url('http'), function (data) {
@@ -377,7 +380,14 @@ function establish_socket() {
                 // type: 'serial-terminal'
                 // msg: [String Base64-encoded message]
 
-                var msg_in = atob(ws_msg.msg);
+                console.log(ws_msg);
+                var msg_in = '';
+                try {
+                    msg_in = atob(ws_msg.msg);
+                } catch (error) {
+                    console.log(error);
+                    msg_in = ws_msg.msg;
+                }
 
                 if (term !== null) { // is the terminal open?
                     pTerm.display(msg_in);

--- a/src/editor.js
+++ b/src/editor.js
@@ -409,7 +409,7 @@ $(() => {
             if (clientService.type === 'http') {
                 clientService.activeConnection.send(btoa(characterToSend));
         
-            } else if (clientService.type === 'websocket' ) {
+            } else if (clientService.type === 'ws' ) {
                 var msg_to_send = {
                     type: 'serial-terminal',
                     outTo: 'terminal',

--- a/src/editor.js
+++ b/src/editor.js
@@ -406,21 +406,19 @@ $(() => {
     pTerm = new PropTerm(
         document.getElementById('serial_console'),
         function(characterToSend) {
-            if (active_connection !== null && 
-                active_connection !== 'simulated' && 
-                active_connection !== 'websocket') {
-                active_connection.send(btoa(characterToSend));
+            if (clientService.type === 'http') {
+                clientService.activeConnection.send(btoa(characterToSend));
         
-            } else if (active_connection === 'websocket' ) {
+            } else if (clientService.type === 'websocket' ) {
                 var msg_to_send = {
                     type: 'serial-terminal',
                     outTo: 'terminal',
                     portPath: getComPort(),
                     baudrate: baudrate.toString(10),
-                    msg: characterToSend,
+                    msg: (clientService.rxBase64 ? btoa(characterToSend) : characterToSend),
                     action: 'msg'
                 };
-                client_ws_connection.send(JSON.stringify(msg_to_send));
+                clientService.activeConnection.send(JSON.stringify(msg_to_send));
             }    
         }
     );

--- a/src/editor.js
+++ b/src/editor.js
@@ -406,7 +406,7 @@ $(() => {
     pTerm = new PropTerm(
         document.getElementById('serial_console'),
         function(characterToSend) {
-            if (clientService.type === 'http') {
+            if (clientService.type === 'http' && clientService.activeConnection) {
                 clientService.activeConnection.send(btoa(characterToSend));
         
             } else if (clientService.type === 'ws' ) {

--- a/src/globals.js
+++ b/src/globals.js
@@ -31,7 +31,7 @@
  *
  * @type {{}}
  */
-let projectData = {};
+let projectData = null;
 
 
 /**

--- a/src/propterm.js
+++ b/src/propterm.js
@@ -329,7 +329,7 @@ class PropTerm {
                 this.buffer.textArray[this.cursor.y] = '';
         }
     
-        if (this.cursor.x < 0) {
+        if (this.cursor.x < 0 && this.cursor.y > 0) {
             this.cursor.y--;
             this.cursor.x = this.buffer.textArray[this.cursor.y].length;
             if (this.cursor.x > this.size.charactersWide - 1) {

--- a/src/style-editor.css
+++ b/src/style-editor.css
@@ -158,7 +158,7 @@ button:hover {
     border: 2px solid black;
 }
 
-#serial-conn-info, #graph-conn-info {
+.connection-string {
     color: #bbb;
     font-size: 11px;
     overflow: hidden;


### PR DESCRIPTION
Much simpler heartbeat/client connection monitoring.  Also fixes a couple of bugs introduced by previous recent commits.

This finishes the client comms work (for now, until the BPC is fully retired).

Testing should involve both BPC and BPL with serial comms, and with no devices, one device, and multiple devices.  Try both loaded programs that invoke the terminal/graph and opening the terminal and graph by clicking their respective toolbar buttons.  Behavior should not deviate from previous behavior, and changes such as disconnecting the client or a device should be reflected in the UI within 7 seconds (3.5 x 2).

Addresses #200 by showing a simulated terminal with both the BPC and BPL when no device is connected.

Comments are included within the code changes for the commits.