### PR TITLE
Update Open Project Save Current Project dialog box message

### DIFF
--- a/src/modals.js
+++ b/src/modals.js
@@ -318,7 +318,7 @@ function OpenProjectModal() {
         if (checkLeave()) {
             const message =
                 'The current project has been modified. Click OK to\n' +
-                'discard the current changes and create a new project.';
+                'discard the current changes and open an existing project.';
 
             utils.confirm(
                 "Abandon Current Project", message,


### PR DESCRIPTION
Updated the wording in the dialog that opens after clicking on the Open button and the current project has unsaved changes to indicate that an existing project will be opened and that it will not create a new project.