### PR TITLE
Updates to add parameter testing

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -461,6 +461,17 @@ function checkLeave() {
  * @returns {boolean} True if projects are unequal, otherwise return false
  */
 function compareProjectCode(projectA, projectB) {
+    // Sanity checks
+    if (typeof projectA === 'undefined') {
+        console.log("project A is undefined.");
+        return true;
+    }
+
+    if (typeof projectB === 'undefined') {
+        console.log("project B is undefined.");
+        return true;
+    }
+
     // Looking for the first <block> XML element
     const searchTerm = '<block';
 
@@ -1826,11 +1837,12 @@ function testProjectEquality(projectA, projectB) {
         console.log("Project description mismatch");
     }
 
-    if (projectA.type !== projectB.type) {
+    if (projectA.projectType !== projectB.projectType) {
+        console.log("ProjectType mismatch")
         return false;
     }
 
-    if (projectA.board !== projectB.board) {
+    if (projectA.boardType !== projectB.boardType) {
         console.log("Board type mismatch");
         return false;
     }
@@ -1841,18 +1853,22 @@ function testProjectEquality(projectA, projectB) {
     }
 
     if (projectA.created !== projectB.created) {
+        console.log("Project created timestamp mismatch");
         return false;
     }
 
     if (projectA.modified !== projectB.modified) {
+        console.log("Project last modified timestamp mismatch");
         return false;
     }
 
     if (projectA.descriptionHtml !== projectB.descriptionHtml) {
+        console.log("Project HTML description mismatch");
         return false;
     }
 
     if (projectA.id !== projectB.id) {
+        console.log("Project A is not the same object as project B");
         return false;
     }
 

--- a/src/project.js
+++ b/src/project.js
@@ -64,7 +64,7 @@ class Project {
 
         this.projectType = ProjectTypes[projectType];
 
-        this.code = (code) ? code : EmptyProjectCodeHeader;
+        this.code = (code) ? code : this.EmptyProjectCodeHeader;
 
         // This should be a timestamp but is received as a string
         // TODO: Convert timestamp string to numeric values
@@ -81,6 +81,18 @@ class Project {
         this.yours = true;
     }
 }
+
+
+/**
+ * Constant string that represents the base, empty project header
+ *
+ * @type {string}
+ *
+ * @description Converting the string to a constant because it is referenced
+ * in a number of places. The string is sufficiently complex that it could
+ * be misspelled without detection.
+ */
+Project.prototype.EmptyProjectCodeHeader = '<xml xmlns="http://www.w3.org/1999/xhtml">';
 
 
 /**
@@ -284,15 +296,3 @@ const ProjectProfiles = {
         saves_to: []
     }
 };
-
-
-/**
- * Constant string that represents the base, empty project header
- *
- * @type {string}
- *
- * @description Converting the string to a constant because it is referenced
- * in a number of places. The string is sufficiently complex that it could
- * be misspelled without detection.
- */
-const EmptyProjectCodeHeader = '<xml xmlns="http://www.w3.org/1999/xhtml">';


### PR DESCRIPTION
Correct an issue where compareProjectCode() was accessing the parameters without validating that they actually contained data.

Refactor the EmptyProjectCodeHeader constant defined in the Project class to become a property of that class. This will enable the global replacement of the EMPTY_PROJECT_CODE_HEADER constant, which is only referenced within the context of project code.

Add console messages to the project comparison function to help identify edge cases when the projects differ.