### PR TITLE
Fix missing array variable

### DIFF
--- a/src/blockly/generators/propc/communicate.js
+++ b/src/blockly/generators/propc/communicate.js
@@ -1923,7 +1923,7 @@ Blockly.Blocks.debug_lcd_init = {
         }
         this.appendDummyInput('PINS')
                 .appendField("Serial LCD initialize PIN")
-                .appendField(new Blockly.FieldDropdown(profile.default.digital.concat(this.map(function (value) {
+                .appendField(new Blockly.FieldDropdown(profile.default.digital.concat(this.userDefinedConstantsList_.map(function (value) {
                     return [value, value]  // returns an array of arrays built from the original array.
                 }))), "PIN")
                 .appendField("baud")


### PR DESCRIPTION
Addresses #231 

Basically was just a copy-paste error when updating variable names in the PR that broke this.