### PR TITLE
Solo 195b fix serial init block part2

### DIFF
--- a/src/blockly/generators/propc/communicate.js
+++ b/src/blockly/generators/propc/communicate.js
@@ -990,9 +990,10 @@ Blockly.Blocks.serial_open = {
         var ck_bits = ['FALSE', 'FALSE', 'FALSE', 'FALSE'];
         var otherMode = false;
         for (var k = 0; k < 4; k++) {
-            ck_bits[k] = xmlElement.getAttribute('ck_bit' + k.toString(10));
-            if (ck_bits[k] === 'TRUE') {
+            var ck_bit = xmlElement.getAttribute('ck_bit' + k.toString(10));
+            if (ck_bit) {
                 otherMode = true;
+                ck_bits[k] = ck_bit;
             }
         }
         if (otherMode) {

--- a/src/blockly/generators/propc/communicate.js
+++ b/src/blockly/generators/propc/communicate.js
@@ -1923,7 +1923,7 @@ Blockly.Blocks.debug_lcd_init = {
         }
         this.appendDummyInput('PINS')
                 .appendField("Serial LCD initialize PIN")
-                .appendField(new Blockly.FieldDropdown(profile.default.digital.concat(this.map(function (value) {
+                .appendField(new Blockly.FieldDropdown(profile.default.digital.concat(this.userDefinedConstantsList_.map(function (value) {
                     return [value, value]  // returns an array of arrays built from the original array.
                 }))), "PIN")
                 .appendField("baud")


### PR DESCRIPTION
Addresses #195, again.

The learning here is that blockly is creating a hidden copy of the block (for sizing/insertion/etc), when you drag a block - and if the new block does not generate the same fields as the existing block has (via the `mutationToDom()` function), it breaks the workspace badly.