### PR TITLE
Correct editor vertical scrollbar issue

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -302,20 +302,26 @@ $(() => {
             return;
         }
 
-        // Store the current project into the localStore so that if the page
-        // is being refreshed, it will automatically be reloaded
-        if (projectData && projectData.name !== "undefined") {
-            // Deep copy of the projectData object
-            let tempProject = {};
-            Object.assign(tempProject, projectData);
+        // If the localStorage is empty, store the current project into the
+        // localStore so that if the page is being refreshed, it will
+        // automatically be reloaded.
+        if (projectData &&
+            projectData.name !== "undefined" &&
+            ! window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)) {
 
-            // Overwrite the code blocks with the current project state
-            tempProject.code = getXml();
-            tempProject.timestamp = getTimestamp();
+            if (! window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)) {
+                // Deep copy of the projectData object
+                let tempProject = {};
+                Object.assign(tempProject, projectData);
 
-            // Save the current project into the browser store where it will
-            // get picked up by the page loading code.
-            window.localStorage.setItem(LOCAL_PROJECT_STORE_NAME, JSON.stringify(tempProject));
+                // Overwrite the code blocks with the current project state
+                tempProject.code = getXml();
+                tempProject.timestamp = getTimestamp();
+
+                // Save the current project into the browser store where it will
+                // get picked up by the page loading code.
+                window.localStorage.setItem(LOCAL_PROJECT_STORE_NAME, JSON.stringify(tempProject));
+            }
         }
 
         if (checkLeave()) {
@@ -1249,7 +1255,7 @@ function downloadCode() {
         // this will allow the project to be reloaded.
         // make the projecData object reflect the current workspace and save it into localStorage
         projectData.timestamp = getTimestamp();
-        projectData.code = EmptyProjectCodeHeader + projectXmlCode + '</xml>';
+        projectData.code = Project.prototype.EmptyProjectCodeHeader + projectXmlCode + '</xml>';
         window.localStorage.setItem(LOCAL_PROJECT_STORE_NAME, JSON.stringify(projectData));
 
         // Mark the time when saved, add 20 minutes to it.
@@ -1379,10 +1385,11 @@ function uploadHandler(files) {
                 uploadedXML = EMPTY_PROJECT_CODE_HEADER + uploadedXML + '</xml>';
             }
 
-            // TODO: check to see if this is used when opened from the editor (and not the splash screen)
+            // TODO: check to see if this is used when opened from the editor
+            //  (and not the splash screen)
             // maybe projectData.code.length < 43??? i.e. empty project? instead of the URL parameter...
 
-            if (window.getURLParameter('openFile') === "true") {
+//            if (window.getURLParameter('openFile') === "true") {
                 // Loading an offline .SVG project file. Create a project object and
                 // save it into the browser store.
                 var titleIndex = xmlString.indexOf('transform="translate(-225,-53)">Title: ');
@@ -1460,7 +1467,7 @@ function uploadHandler(files) {
 
                 // Save the project to the browser store
                 window.localStorage.setItem(TEMP_PROJECT_STORE_NAME, JSON.stringify(pd));
-            }
+//            }
         }
 
         if (xmlValid === true) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -1255,7 +1255,8 @@ function downloadCode() {
         // this will allow the project to be reloaded.
         // make the projecData object reflect the current workspace and save it into localStorage
         projectData.timestamp = getTimestamp();
-        projectData.code = Project.prototype.EmptyProjectCodeHeader + projectXmlCode + '</xml>';
+        // projectData.code = Project.prototype.EmptyProjectCodeHeader + projectXmlCode + '</xml>';
+        projectData.code = EMPTY_PROJECT_CODE_HEADER + projectXmlCode + '</xml>';
         window.localStorage.setItem(LOCAL_PROJECT_STORE_NAME, JSON.stringify(projectData));
 
         // Mark the time when saved, add 20 minutes to it.

--- a/src/modals.js
+++ b/src/modals.js
@@ -331,6 +331,9 @@ function OpenProjectModal() {
                 "Cancel",
                 "OK");
         }
+        else {
+            OpenProjectModalSetHandlers();
+        }
     } else {
         // The project has not changed. Continue with the dialog.
         OpenProjectModalSetHandlers();
@@ -355,10 +358,10 @@ function OpenProjectModalSetHandlers() {
  *
  * @description
  * When a project is selected, the code responsible for retrieving
- * project from disk will store it in the browser's localStorage
- * under the key value TEMP_PROJECT_STORE_NAME. That same code will
- * return control to the Open Project modal, where the user can
- * select Open or Cancel.
+ * project from disk, uploadHandler(), will store it in the browser's
+ * localStorage under the key value TEMP_PROJECT_STORE_NAME. That
+ * same code will return control to the Open Project modal, where the
+ * user can select Open or Cancel.
  *
  * This event handler is invoked when the user selects the Open
  * button. It looks for a project in the browser's local
@@ -384,6 +387,9 @@ function OpenProjectModalOpenClick() {
             // eslint-disable-next-line no-undef
             window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
             window.location = 'blocklyc.html';
+        }
+        else {
+            console.log("The opened project cannot be found in storage");
         }
     });
 }


### PR DESCRIPTION
The vertical scrollbar on the editor canvas was not rendering for large projects. Further testing against the 1.3.512 build was unable to reproduce the issue. However, a new issue was discovered where loading a new project would result in the previous project, if there was one, would be loaded onto the editor canvas.

The root cause was that the code responsible for loading a project from the localStorage was not clearing the localStorage after the project was loaded. All other components expect the localStorage to be clear (empty) if there is no successor to the currently loaded project.