### PR TITLE
Correct error in query sting processing in issue #167

### DIFF
--- a/src/modals.js
+++ b/src/modals.js
@@ -425,7 +425,7 @@ function OpenProjectModalEscapeClick() {
      * closed when the user clicks on the 'x' icon.
      */
     $('#open-project-dialog').on('hidden.bs.modal', function () {
-        if (!projectData | typeof(projectData.board) === 'undefined') {
+        if (!projectData || typeof projectData.board === 'undefined') {
             // If there is no project, go to home page.
             window.location.href = 'index.html';
         }

--- a/src/modals.js
+++ b/src/modals.js
@@ -386,7 +386,7 @@ function OpenProjectModalOpenClick() {
 
             // eslint-disable-next-line no-undef
             window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
-            window.location = 'blocklyc.html';
+            window.location = 'blocklyc.html'+ window.getAllURLParameters();
         }
         else {
             console.log("The opened project cannot be found in storage");


### PR DESCRIPTION
Found two errors in the modal.js file related to loading a project with an experimental query string component. The first was not detecting a null project and forcing the redirect. The second issue was the Open Project feature was truncating the experimental query string after successfully loading the target project.