### PR TITLE
Remove semicolon that is clobbering code generation

### DIFF
--- a/src/blockly/generators/propc/sensors.js
+++ b/src/blockly/generators/propc/sensors.js
@@ -1353,7 +1353,7 @@ Blockly.propc.lis3dh_temp = function () {
         p = this.getFieldValue('CS_PIN');
     }
     if (p) {
-        return ['lis3dh_temp_' + unit + '(lis3dh_' + p + ');', Blockly.propc.ORDER_NONE];
+        return ['lis3dh_temp_' + unit + '(lis3dh_' + p + ')', Blockly.propc.ORDER_NONE];
     } else {
         return ['0 // WARNING: Missing init block!', Blockly.propc.ORDER_NONE];
     }


### PR DESCRIPTION
Addresses #242 

Extra semicolon is causing an issue with the generated code.  This PR removes it.