### PR TITLE
Update Launcher client URLs

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -46,9 +46,9 @@
     <meta name="win64client" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-64.exe">
     <meta name="win64zipclient" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-64.zip">
     <meta name="macOSclient" content="http://downloads.parallax.com/blockly/clients/BlocklyPropClient-setup-MacOS.pkg">
-    <meta name="win64launcher" content="http://downloads.parallax.com/blockly/clients/launcher/Setup-BPLauncher-v0.11.0-Win.exe">
-    <meta name="win64ziplauncher" content="http://downloads.parallax.com/blockly/clients/launcher/Setup-BPLauncher-v0.11.0-Win.exe.zip">
-    <meta name="macOSlauncher" content="http://downloads.parallax.com/blockly/clients/launcher/Setup-BPLauncher-v0.11.0-MacOS.zip">
+    <meta name="win64launcher" content="http://downloads.parallax.com/blockly/launcher/Setup-BPLauncher-Win.exe">
+    <meta name="win64ziplauncher" content="http://downloads.parallax.com/blockly/launcher/Setup-BPLauncher-Win.exe.zip">
+    <meta name="macOSlauncher" content="http://downloads.parallax.com/blockly/launcher/Setup-BPLauncher-MacOS.zip">
 
     <meta name="application-name" content="BlocklyProp Solo" />
     <meta name="msapplication-TileColor" content="#FFFFFF" />

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
                             <li><a onclick="showLicense()">License</a></li>
                             <li>
                                 <a href="http://www.parallax.com" target="_blank">
-                                v1.4.0 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
+                                v1.4.1 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
Addresses issue #252 
Update links to new generic latest version launcher files to new location in S3. This also realigns the release cycle directory tree such that the latest release is always in the /blockly/launcher folder and specific release numbers are in their respective sub folders. For example, release 0.11.0 is now located in the /blockly/launcher/0.11.0/ folder.

Bump version number of next milestone.