### PR TITLE
Update BP Launcher upgrade message

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -840,7 +840,7 @@
         </div>
     </div>
 
-    <!-- Enumerate the versions of the client installer available -->
+    <!-- Modal window that enumerates the versions of the client installer available -->
     <div class="modal fade" id="client-version-modal">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -998,17 +998,10 @@
                                     <span class="keyed-lang-string" data-key="os_name_chr"></span>
                                 </a>
                             </li>
-                            <!--
-                            <li>
-                                <a href="#" class="show-os-lnx">
-                                    <span class="keyed-lang-string" data-key="os_name_lnx"></span>
-                                </a>
-                            </li>
-                             -->
                         </ul>
                     </div>
-                    <button style="display:inline-block; margin-left:20px;" 
-                            class="btn btn-sm btn-primary" 
+                    <button style="display: inline;"
+                            class="btn btn-sm btn-primary"
                             onclick="$('.bpc-old').removeClass('hidden'); $(this).addClass('hidden');">
                         Show BlocklyProp-Client (older) downloads</button>
                 </div>

--- a/src/blockly/language/en/messages.js
+++ b/src/blockly/language/en/messages.js
@@ -800,7 +800,7 @@ page_text_label['clientdownload_showall'] = "Show clients for all operating syst
 page_text_label['clientdownload_title'] = "BlocklyProp Launcher";
 
 page_text_label['client_unknown'] = "BlocklyProp is unable to determine what version of BlocklyProp Launcher is installed on your computer.<br>You may need to install or reinstall the BlocklyProp Launcher.";
-page_text_label['client_update_warning'] = "BlocklyProp now recommends at least version <span class=\"client-required-version\"></span> of BlocklyProp Launcher.<br>You appear to be using BlocklyProp Launcher version <span class=\"client-your-version\"></span>.<br>Please use the link below to download the newest version of BlocklyProp Launcher.";
+page_text_label['client_update_warning'] = "BlocklyProp Solo requires BlocklyProp Launcher version <span class=\"client-required-version\"></span>, or later.<br>You are using incompatible software: BlocklyProp Client version <span class=\"client-your-version\"></span>.<br>Download and install the latest software from the link below.";
 page_text_label['client_update_danger'] = "BlocklyProp now requires at least version <span class=\"client-required-version\"></span> of BlocklyProp Launcher.<br>You appear to be using BlocklyProp Launcher version <span class=\"client-your-version\"></span>.<br>You will not be able to load projects to your device until you upgrade your BlocklyProp Launcher.<br>Please use the link below to download the newest version.";
 
 page_text_label['confirm_do_email'] = "Email:";


### PR DESCRIPTION
This PR addresses issue #247.
It reworks the message as specified and corrects an issue where the 'Older Clients' button was mis-aligned below the 'OS-Selector' drop down element