### PR TITLE
Patch develop 311

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
                             <li><a onclick="showLicense()">License</a></li>
                             <li>
                                 <a href="http://www.parallax.com" target="_blank">
-                                v1.4.2.3 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
+                                v1.4.2.4 Parallax &copy; 2015 - <span id="footer_copyright"></span></a>
                             </li>
                         </ul>
                     </div>

--- a/src/blockly/generators/propc/sensors.js
+++ b/src/blockly/generators/propc/sensors.js
@@ -1082,21 +1082,21 @@ Blockly.Blocks.lis3dh_init = {
                 .appendField(
                     new Blockly.FieldNumber(
                         '0',
-                        -500,
-                        500,
+                        null,
+                        null,
                         1
                     ),"VSS_VOLTAGE")
                 .appendField(' 3.3V ')
                 .appendField(
                     new Blockly.FieldNumber(
                         '0',
-                        2700,
-                        3800,
+                        null,
+                        null,
                         1
                     ), "VDD_VOLTAGE");
 
             this.setFieldValue(vssVoltField || '0', 'VSS_VOLTAGE');
-            this.setFieldValue(vddVoltField || '3300', 'VDD_VOLTAGE');
+            this.setFieldValue(vddVoltField || '0', 'VDD_VOLTAGE');
 
             // Move this input field to the bottom of the init block
             this.moveInputBefore('VOLT_CALIBRATE', null);

--- a/src/blockly/generators/propc/sensors.js
+++ b/src/blockly/generators/propc/sensors.js
@@ -1176,7 +1176,14 @@ Blockly.propc.lis3dh_init = function () {
             var vddVoltField = this.getFieldValue('VDD_VOLTAGE');
 
             if ((vssVoltField !== undefined) && (vddVoltField !== undefined)) {
-                setupCode += 'lis3dh_adcCal_mV(lis3dh_sensor, 0, 3300, ' + vssVoltField + ', ' + vddVoltField + ');';
+                setupCode += 'lis3dh_adcCal_mV(lis3dh_sensor, ';
+
+                if (vssVoltField === 0 && vddVoltField === 0) {
+                    setupCode += '0, 0, 0, 0 );';
+                }
+                else {
+                    setupCode += '0, 3300, ' + vssVoltField + ', ' + vddVoltField + ');';
+                }
             }
         }
 


### PR DESCRIPTION
Addresses continuing issues wth #311 

This update addresses an error discovered in testing the new ADC calibration code. The adc_init() must be called with four zero parameters during calibration. After the user has provided the ground and 3.3.V adjustments, the first two parameters in adc_init() must be set to 0, 3300. The remaining two parameters are the user supplied ground and 3.3V settings.
