### PR TITLE
Solo 200 resubmit E client URL formatting function

### DIFF
--- a/src/blocklyc.js
+++ b/src/blocklyc.js
@@ -616,7 +616,7 @@ function loadInto(modal_message, compile_command, load_option, load_action) {
 
                 if (clientService.version.isCoded) {
                     //Request load with options from BlocklyProp Client
-                    $.post("http://" + client_domain_name + ":" + client_domain_port + "/load.action", {
+                    $.post(clientService.url("load.action"), {
                         option: load_option,
                         action: load_action,
                         binary: data.binary,
@@ -662,7 +662,7 @@ function loadInto(modal_message, compile_command, load_option, load_action) {
                 } else {
                     //TODO: Remove this once client_min_version is >= minCodedVer
                     //Request load without options from old BlocklyProp Client
-                    $.post("http://" + client_domain_name + ":" + client_domain_port + "/load.action", {
+                    $.post(clientService.url("load.action"), {
                         action: load_action,
                         binary: data.binary,
                         extension: data.extension,
@@ -707,9 +707,7 @@ function serial_console() {
         }
 
         if (ports_available) {
-            var url = "http://" + client_domain_name + ":" + client_domain_port + "/serial.connect";
-            url = url.replace('http', 'ws');
-            var connection = new WebSocket(url);
+            var connection = new WebSocket(clientService.url("serial.connect", "ws"));
 
             // When the connection is open, open com port
             connection.onopen = function () {
@@ -892,7 +890,7 @@ function graphing_console() {
         }
 
         if (client_use_type !== 'ws' && ports_available) {
-            var connection = new WebSocket("ws://" + client_domain_name + ":" + client_domain_port + "/serial.connect");
+            var connection = new WebSocket(clientService.url("serial.connect", "ws"));
 
             // When the connection is open, open com port
             connection.onopen = function () {
@@ -1041,13 +1039,11 @@ var graphStartStop = function (action) {
 var checkForComPorts = function () {
     // TODO: We need to evaluate this when using web sockets ('ws') === true
     if (client_use_type !== 'ws') {
-        if (client_domain_name && client_domain_port) {
-            $.get("http://" + client_domain_name + ":" + client_domain_port + "/ports.json", function (data) {
-                set_port_list(data);
-            }).fail(function () {
-                set_port_list();
-            });
-        }
+        $.get(clientService.url("ports.json"), function (data) {
+            set_port_list(data);
+        }).fail(function () {
+            set_port_list();
+        });
     }
 };
 

--- a/src/blocklypropclient.js
+++ b/src/blocklypropclient.js
@@ -135,11 +135,10 @@ var clientService = {
 }
 
 // Status Notice IDs
-//const NS_DOWNLOADING                = 002;
-//const NS_DOWNLOAD_SUCCESSFUL         = 005;
-const NS_DOWNLOADING                = 2;
+//const NS_DOWNLOADING               = 002;
+//const NS_DOWNLOAD_SUCCESSFUL       = 005;
+const NS_DOWNLOADING                 = 2;
 const NS_DOWNLOAD_SUCCESSFUL         = 5;
-
 
 // Error Notice IDs
 const NE_DOWNLOAD_FAILED             = 102;
@@ -160,22 +159,6 @@ var find_client = function () {
         // WebSocket'd launcher not found?  Try Http'd client
         check_client();
     }
-};
-
-var version_as_number = function (rawVersion) {
-    var tempVersion = rawVersion.toString().split(".");
-    tempVersion.push('0');
-
-    if (tempVersion.length < 3) {
-        if (tempVersion.length === 1)
-            tempVersion = '0.0.0';
-        else
-            tempVersion.unshift('0');
-    }
-
-    // Allow for any of the three numbers to be between 0 and 1023.
-    // Equivalent to: (Major * 104856) + (Minor * 1024) + Revision.
-    return (Number(tempVersion[0]) << 20 | Number(tempVersion[1]) << 10 | Number(tempVersion[2]));
 };
 
 var setPropToolbarButtons = function (ui_btn_state) {

--- a/src/blocklypropclient.js
+++ b/src/blocklypropclient.js
@@ -95,7 +95,7 @@ var clientService = {
     activeConnection: null,
     */
     url: function (location, protocol) {
-        return (protocol || window.location.protocol) + '://' + this.path + ':' + this.port + '/' + (location || '');
+        return (protocol || window.location.protocol.replace(':', '')) + '://' + this.path + ':' + this.port + '/' + (location || '');
     },
     version: {
         // Constants

--- a/src/blocklypropclient.js
+++ b/src/blocklypropclient.js
@@ -41,47 +41,6 @@ var client_available = false;
 var ports_available = false;
 
 
-/**
- * The version number the BlocklyProp Client reported
- *
- * @type {number}
- */
-var client_version = 0;
-
-
-// TODO: Verify that this variable is a host name and not a domain name
-/**
- * Client host name
- *
- * @type {string}
- */
-var client_domain_name = "localhost";
-
-
-/**
- * Port number component of the BlocklyProp Client interface
- *
- * @type {number}
- */
-var client_domain_port = 6009;
-
-
-/**
- * The minimum version of the BlocklyProp Client that can be used with this interface
- *
- * @type {string}
- */
-var client_min_version = "0.7.0";
-
-
-/**
- * The most recent version of the BlocklyPro Client that can be used with this interface
- *
- * @type {string}
- */
-var client_recommended_version = "0.8.0";
-
-
 // TODO: Document what the 'client_use_type' variable represents
 /**
  * Not sure what this does
@@ -126,16 +85,18 @@ var clientService = {
     /*
     available: false,
     portsAvailable: false,
+    */
     path: 'localhost',
     port: 6009,
+    /*
     type: null,
     rxBase64: true,
     portListReceiveCountUp: 0,  // This is set to 0 each time the port list is received, and incremented once each 4 second heartbeat
     activeConnection: null,
-    url: function (protocol) {
-        return protocol + '://' + this.path + ':' + this.port + '/';
-    },
     */
+    url: function (location, protocol) {
+        return (protocol || window.location.protocol) + '://' + this.path + ':' + this.port + '/' + (location || '');
+    },
     version: {
         // Constants
         MINIMUM_ALLOWED: '0.7.0',
@@ -279,7 +240,7 @@ function checkClientVersionModal(rawVersion) {
  * This is evaluating the BlocklyProp Client or BlocklyProp Launcher version??
  */
 var check_client = function () {
-    $.get("http://" + client_domain_name + ":" + client_domain_port + "/", function (data) {
+    $.get(clientService.url(), function (data) {
         if (!client_available) {
             let client_version_str = (typeof data.version_str !== "undefined") ? data.version_str : data.version;
             if (!data.server || data.server !== 'BlocklyPropHTTP') {
@@ -347,7 +308,7 @@ var configure_client = function () {
         id: "domain_name",
         type: "text",
         class: "form-control",
-        value: client_domain_name
+        value: clientService.path
     }).appendTo(domain_name_group);
 
     // Hard code the ':' between the domain name and port input fields
@@ -365,14 +326,14 @@ var configure_client = function () {
         id: "port_number",
         type: "number",
         class: "form-control",
-        value: client_domain_port
+        value: clientService.port
     }).appendTo(domain_port_group);
 
     // Show the modal dialog
     utils.confirm(Blockly.Msg.DIALOG_BLOCKLYPROP_LAUNCHER_CONFIGURE_TITLE, url_input, function (action) {
         if (action) {
-            client_domain_name = $("#domain_name").val();
-            client_domain_port = $("#port_number").val();
+            clientService.path = $("#domain_name").val();
+            clientService.port = $("#port_number").val();
         }
     }, Blockly.Msg.DIALOG_SAVE_TITLE);
 };
@@ -386,8 +347,7 @@ function establish_socket() {
         // Clear the port list
         set_port_list();
 
-        var url = "ws://" + client_domain_name + ":" + client_domain_port + "/";
-        var connection = new WebSocket(url);
+        var connection = new WebSocket(clientService.url('', 'ws'));
 
         connection.onopen = function () {
 


### PR DESCRIPTION
Continues addressing #279 
Adds a client connection URL generating function to the `clientService` object.
Cleans up some dead/unused code

To Test:
Make sure solo is able to connect to both the BPC and BPL, including:
 - showing connection
 - enumerating ports
 - facilitating serial/console/terminal comms
 - load programs to propeller devices