### PR TITLE
Solo 200 resubmit G - Handle differences in encoding between launcher versions

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -302,7 +302,7 @@ $(() => {
                     outTo: 'terminal',
                     portPath: getComPort(),
                     baudrate: baudrate.toString(10),
-                    msg: characterToSend,
+                    msg: (clientService.rxBase64 ? btoa(characterToSend) : characterToSend),
                     action: 'msg'
                 };
                 client_ws_connection.send(JSON.stringify(msg_to_send));


### PR DESCRIPTION
Continues addressing #279 
The launcher was not encoding one direction of its serial comms stream.  There is a PR in the lanucher's repo holding on this change:
[BlocklyPropLanucher-96](https://github.com/parallaxinc/BlocklyPropLauncher/pull/96)
This adds code to compensate for that issue across all versions of the launcher.