### PR TITLE
solo 339 - Check for connection before deleting it

### DIFF
--- a/src/blockly/generators/propc/gpio.js
+++ b/src/blockly/generators/propc/gpio.js
@@ -1276,8 +1276,11 @@ Blockly.Blocks.sound_play = {
     setSoundAction: function (action) {
         var valueBlock = null;
         if (action !== this.getFieldValue('ACTION')) {
-            if (this.getInput('VALUE')) {
-                valueBlock = this.getInput('VALUE').connection.targetBlock();
+            var targetInput = this.getInput('VALUE');
+            if (targetInput) {
+                if (targetInput.connection) {
+                    valueBlock = targetInput.connection.targetBlock();
+                }
                 this.removeInput('VALUE');
             }
             if (action === 'wave') {


### PR DESCRIPTION
Addresses #339 

To reproduce error:
- build the following program:
![image](https://user-images.githubusercontent.com/19737272/76012807-c1bd4480-5ecb-11ea-936d-82fa4b38c3b0.png)
- select "waveform" first, then try changing that same menu to a different option - that should reproduce it.

This PR corrects the bug by checking for the connection before trying to access/delete it.

To test:
- same steps as above, make sure no error is generated.