### PR TITLE
Correct Load to RAM button for S3 projects

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -160,7 +160,8 @@ $(() => {
     RenderPageBrandingElements();
 
     // Set the compile toolbar buttons to unavailable
-    setPropToolbarButtons();
+    // setPropToolbarButtons();
+    PropToolbarButtonController(false);
 
     /* -- Set up amy event handlers once the DOM is ready -- */
 
@@ -269,6 +270,11 @@ $(() => {
             setupWorkspace(localProject, function () {
                 window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
             });
+
+            // Set the compile toolbar buttons to unavailable
+            // setPropToolbarButtons();
+            PropToolbarButtonController(false);
+
         } catch (objError) {
             if (objError instanceof SyntaxError) {
                 console.error(objError.name);


### PR DESCRIPTION
Replaced setPropToolbarButtons function with PropToolbarButtonController.

Refactored old function to remove the reference to the clientService class.
Add code in the editor.js to properly set the button state when loading a project without regard to the client connection state.
