### PR TITLE
Solo 365 - Fix RXTX dropdown on serial protocol blocks

### DIFF
--- a/src/blockly/generators/propcToolbox.js
+++ b/src/blockly/generators/propcToolbox.js
@@ -829,7 +829,7 @@ xmlToolbox += '            </block>';
 xmlToolbox += '        </category>';
 
 xmlToolbox += '        <category key="category_communicate_protocols" exclude="heb,heb-wx,">';
-xmlToolbox += '            <block type="serial_open"></block>';
+xmlToolbox += '            <block type="serial_open"><field name="TXPIN">1</field></block>';
 xmlToolbox += '            <block type="serial_send_text"></block>';
 xmlToolbox += '            <block type="serial_status"></block>';
 xmlToolbox += '            <block type="serial_print_multiple"></block>';


### PR DESCRIPTION
Refactors the functions that handle the RXTX (pin selection) dropdown in the serial protocol blocks.
- Transitions the mechanism from using "sending" functions in the serial intialize blocks to monitoring `onchange` events for pin menu changes in the init block.
- Collapses the functions handling menu building and change monitoring were collapsed and generalized, allowing them to be copied into all other blocks.
- Uses a new method (`array.filter`) to find the difference between past and updated states, allowing for more efficient monitoring of menu changes that apply to the block in question.
- Tests for existence of field test before setting its value (may want to apply this elsewhere down the road)

To test:
- Create a project using a *serial init* block and each of the other serial protocol blocks.
- Move them around, make sure they do not present an RXTX menu.
- Add additional *serial init* blocks and change their pin menus
- Ensure that an RXTX menu appears on all blocks and that that menu reflects the RX and TX selections on the *serial init* blocks.
- Make changes to the RX and TX selections on the *serial init* blocks.  Make sure the changes are reflected in the RXTX menus of the serial protocol blocks.
- Delete blocks.  Make sure nothing breaks and that menus change to a different option if the pin options it has are no longer an available option.