### PR TITLE
Begin migration to ES6 modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 
+# Ignore the library folder, it's not directly ours to deal with
+src/lib/*
 
-# Ignore everything
-src/*
-!src/modules/*
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,11 +1,6 @@
-src/lib/*
-src/blockly/*
-src/blockly.js
-src/blocklypropclient.js
-src/editor.js
-src/globals.js
-src/modals.js
-src/propterm.js
-src/project.js
-src/utils.js
+
+
+# Ignore everything
+src/*
+!src/modules/*
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,10 @@
 src/lib/*
+src/blockly/*
+src/blockly.js
+src/blocklypropclient.js
+src/editor.js
+src/globals.js
+src/modals.js
+src/propterm.js
+src/utils.js
+

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,6 @@ src/editor.js
 src/globals.js
 src/modals.js
 src/propterm.js
+src/project.js
 src/utils.js
 

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -35,3 +35,8 @@ rules:
   no-useless-escape: warn
   no-undef: warn
   no-unused-vars: warn
+overrides:
+  - files: ["src/modules/**/*.js"]
+    parserOptions:
+      sourceType: module
+

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,7 +2,7 @@ env:
   browser: true
   es6: true
 extends:
-  - google
+  - eslint:recommended
 globals:
   $: readonly
   ace: readonly
@@ -37,6 +37,8 @@ rules:
   no-unused-vars: warn
 overrides:
   - files: ["src/modules/**/*.js"]
+    extends:
+      - google
     parserOptions:
       sourceType: module
 

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,8 @@
 env:
   browser: true
   es6: true
-extends: 'eslint:recommended'
+extends:
+  - google
 globals:
   $: readonly
   ace: readonly

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         </script>
         <script type="application/javascript" src="src/globals.js" defer></script>
         <script type="application/javascript" src="src/utils.js" defer></script>
-        <script type="application/javascript" src="src/index.js" defer></script>
+        <script type="module" src="src/index.js" defer></script>
     </head>
 
     <body>
@@ -149,7 +149,10 @@
                 <div class="container">
                     <div>
                         <ul class="nav navbar-nav navbar-right">
-                            <li><a onclick="showLicense()">License</a></li>
+                            <!--
+                            <li><a id="show_license" onclick="showLicense()">License</a></li>
+                            -->
+                            <li><a id="show_license">License</a></li>
                             <li>
                                 <a href="http://www.parallax.com" target="_blank">
                                 v1.4.2e Parallax &copy; 2015 - <span id="footer_copyright"></span></a>

--- a/index.html
+++ b/index.html
@@ -36,36 +36,32 @@
         <meta name="application-name" content="BlocklyProp"/>
         <meta name="msapplication-TileColor" content="#FFFFFF"/>
         <meta name="msapplication-TileImage" content="src/images/mstile-144x144.png"/>
-
         <meta name="base" content="">
         <meta name="cdn" content="src/">
-    
+
+        <link rel="stylesheet" href="src/lib/bootstrap/core/css/bootstrap.min.css"/>
+        <link rel="stylesheet" href="src/lib/bootstrap/plugins/bootstrap-table.min.css"/>
+        <link type="text/css" rel="stylesheet" href="src/style.css"/>
+
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="57x57" href="src/images/apple-touch-icon-57x57.png"/>
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="114x114" href="src/images/apple-touch-icon-114x114.png"/>
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="72x72" href="src/images/apple-touch-icon-72x72.png"/>
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="144x144" href="src/images/apple-touch-icon-144x144.png"/>
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="120x120" href="src/images/apple-touch-icon-120x120.png"/>
         <link type="image/png" rel="apple-touch-icon-precomposed" sizes="152x152" href="src/images/apple-touch-icon-152x152.png"/>
-
         <link type="image/png" rel="icon" sizes="32x32" href="src/images/favicon-32x32.png"/>
         <link type="image/png" rel="icon" sizes="16x16" href="src/images/favicon-16x16.png"/>
 
-        <link type="text/css" rel="stylesheet" href="src/style.css"/>
-
-        <link rel="stylesheet" href="src/lib/bootstrap/core/css/bootstrap.min.css"/>
-        <link rel="stylesheet" href="src/lib/bootstrap/plugins/bootstrap-table.min.css"/>
-
         <title>BlocklyProp Solo</title>
-
-        <script type="application/javascript" src="src/lib/jquery-1.11.3.min.js"></script>
-        <script type="application/javascript" src="src/lib/bootstrap/core/js/bootstrap.min.js"></script>
+        <script type="application/javascript" src="src/lib/jquery-1.11.3.min.js" defer></script>
+        <script type="application/javascript" src="src/lib/bootstrap/core/js/bootstrap.min.js" defer></script>
         <script src="https://browser.sentry-cdn.com/5.12.1/bundle.min.js"
                 integrity="sha384-y+an4eARFKvjzOivf/Z7JtMJhaN6b+lLQ5oFbBbUwZNNVir39cYtkjW1r6Xjbxg3"
-                crossorigin="anonymous">
+                crossorigin="anonymous" defer>
         </script>
-        <script type="application/javascript" src="src/globals.js"></script>
-        <script type="application/javascript" src="src/utils.js"></script>
-        <script type="application/javascript" src="src/index.js"></script>
+        <script type="application/javascript" src="src/globals.js" defer></script>
+        <script type="application/javascript" src="src/utils.js" defer></script>
+        <script type="application/javascript" src="src/index.js" defer></script>
     </head>
 
     <body>
@@ -76,7 +72,7 @@
                 </div>
                 <!-- Projects -->
                 <div class="collapse navbar-collapse" id="navbar-collapse">
-                    <ul class="nav navbar-nav">                
+                    <ul class="nav navbar-nav">
                         <li><a class="editor-link" href="blocklyc.html?openFile=true">Open project</a></li>
                         <li><a class="editor-link" href="blocklyc.html?newProject=true">New project</a></li>
                         <li id="noScript">

--- a/index.html
+++ b/index.html
@@ -61,7 +61,8 @@
         </script>
         <script type="application/javascript" src="src/globals.js" defer></script>
         <script type="application/javascript" src="src/utils.js" defer></script>
-        <script type="module" src="src/index.js" defer></script>
+        <script type="module" src="src/modules/constants.js" defer></script>
+        <script type="module" src="src/modules/index.js" defer></script>
     </head>
 
     <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,6 +2063,12 @@
         "v8-compile-cache": "^2.0.3"
       }
     },
+    "eslint-config-google": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
+      "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai": "^4.2.0",
     "copy-webpack-plugin": "^5.1.1",
     "eslint": "^6.6.0",
+    "eslint-config-google": "^0.14.0",
     "mocha": "^6.2.2",
     "sinon": "^7.5.0",
     "webpack": "^4.42.0",

--- a/src/blockly/generators/propc/communicate.js
+++ b/src/blockly/generators/propc/communicate.js
@@ -148,7 +148,7 @@ Blockly.propc.console_print_variables = function () {
                 value = '(' + value + ' & 0xFF)'
             }
         }
-    
+
         code += ', ' + value + ');\n';
     } else {
         code += ', ' + value + ');\n';
@@ -316,10 +316,10 @@ Blockly.Blocks.console_print_multiple = {
     decompose: function (workspace) {
         var containerBlock = workspace.newBlock('console_print_container');
         var subBlock = 'console_print_';
-        if (this.type === 'console_print_multiple' || 
-                this.type === 'oled_print_multiple' || 
+        if (this.type === 'console_print_multiple' ||
+                this.type === 'oled_print_multiple' ||
                 this.type === 'epaper_print_multiple' ||
-                this.type === 'debug_lcd_print_multiple' || 
+                this.type === 'debug_lcd_print_multiple' ||
                 this.type === 'parallel_lcd_print_multiple' ||
                 this.type === 'heb_print_multiple') {
             containerBlock.initSvg();
@@ -1271,7 +1271,7 @@ Blockly.Blocks.serial_send_text = {
         }
         this.updateSerPin();
         if (this.getInput('SERPIN')) {
-            this.removeInput('SERPIN');
+            this.removeInput('SERPIN');         // WHY??
         }
         if (this.ser_pins.length > 1) {
             this.appendDummyInput('SERPIN')
@@ -1918,7 +1918,7 @@ Blockly.Blocks.serial_scan_multiple = {
             i++;
             optionBlock = optionBlock.nextConnection &&
                     optionBlock.nextConnection.targetBlock();
-        }  
+        }
     },
     serPins: Blockly.Blocks['serial_send_text'].serPins,
     updateSerPin: Blockly.Blocks['serial_send_text'].updateSerPin,
@@ -2389,7 +2389,7 @@ Blockly.Blocks.debug_lcd_print = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-        if ((allBlocks.indexOf('Serial LCD initialize') === -1 && this.type === 'debug_lcd_print') || 
+        if ((allBlocks.indexOf('Serial LCD initialize') === -1 && this.type === 'debug_lcd_print') ||
                 (allBlocks.indexOf('Parallel LCD initialize') === -1 && this.type === 'parallel_lcd_print'))
         {
             this.setWarningText('WARNING: You must use an LCD\ninitialize block at the beginning of your program!');
@@ -2405,7 +2405,7 @@ Blockly.propc.debug_lcd_print = function () {
     if (this.type === 'parallel_lcd_print') {
         st = 'parallel';
     }
-    if ((allBlocks.indexOf('Serial LCD initialize') === -1 && st === 'serial') || 
+    if ((allBlocks.indexOf('Serial LCD initialize') === -1 && st === 'serial') ||
     (allBlocks.indexOf('Parallel LCD initialize') === -1 && st === 'parallel')) {
         return '// ERROR: LCD is not initialized!\n';
     } else {
@@ -2437,7 +2437,7 @@ Blockly.Blocks.debug_lcd_number = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-        if ((allBlocks.indexOf('Serial LCD initialize') === -1 && this.type === 'debug_lcd_number') || 
+        if ((allBlocks.indexOf('Serial LCD initialize') === -1 && this.type === 'debug_lcd_number') ||
                 (allBlocks.indexOf('Parallel LCD initialize') === -1 && this.type === 'parallel_lcd_number'))
         {
             this.setWarningText('WARNING: You must use an LCD\ninitialize block at the beginning of your program!');
@@ -2453,7 +2453,7 @@ Blockly.propc.debug_lcd_number = function () {
     if (this.type === 'parallel_lcd_print') {
         st = 'parallel';
     }
-    if ((Blockly.getMainWorkspace().getBlocksByType('debug_lcd_init').length === 0 && st === 'serial') || 
+    if ((Blockly.getMainWorkspace().getBlocksByType('debug_lcd_init').length === 0 && st === 'serial') ||
     (Blockly.getMainWorkspace().getBlocksByType('parallel_lcd_init').length === 0 && st === 'parallel')) {
         code += '// ERROR: LCD is not initialized!\n';
     } else {
@@ -2545,7 +2545,7 @@ Blockly.Blocks.debug_lcd_set_cursor = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-        if ((allBlocks.indexOf('Serial LCD initialize') === -1 && this.type === 'debug_lcd_set_cursor') || 
+        if ((allBlocks.indexOf('Serial LCD initialize') === -1 && this.type === 'debug_lcd_set_cursor') ||
                 (allBlocks.indexOf('Parallel LCD initialize') === -1 && this.type === 'parallel_lcd_set_cursor'))
         {
             this.setWarningText('WARNING: You must use an LCD\ninitialize block at the beginning of your program!');
@@ -2556,7 +2556,7 @@ Blockly.Blocks.debug_lcd_set_cursor = {
 };
 
 Blockly.propc.debug_lcd_set_cursor = function () {
-    if ((Blockly.getMainWorkspace().getBlocksByType('debug_lcd_init').length === 0 && this.type === 'debug_lcd_set_cursor') || 
+    if ((Blockly.getMainWorkspace().getBlocksByType('debug_lcd_init').length === 0 && this.type === 'debug_lcd_set_cursor') ||
             (Blockly.getMainWorkspace().getBlocksByType('parallel_lcd_init').length === 0 && this.type === 'parallel_lcd_set_cursor')) {
         return '// LCD is not initialized!\n';
     } else {
@@ -2609,7 +2609,7 @@ Blockly.Blocks.debug_lcd_print_multiple = {
         if (this.workspace && this.optionList_.length < 1) {
             warnTxt = 'LCD print multiple must have at least one term.';
         }
-        if ((Blockly.getMainWorkspace().getBlocksByType('debug_lcd_init').length === 0 && this.type === 'debug_lcd_print_multiple') || 
+        if ((Blockly.getMainWorkspace().getBlocksByType('debug_lcd_init').length === 0 && this.type === 'debug_lcd_print_multiple') ||
                 (Blockly.getMainWorkspace().getBlocksByType('parallel_lcd_init').length === 0 && this.type === 'parallel_lcd_print_multiple')) {
             warnTxt = 'WARNING: You must use an LCD\ninitialize block at the beginning of your program!';
         }
@@ -3158,10 +3158,10 @@ Blockly.Blocks.oled_initialize = {
 Blockly.propc.oled_initialize = function () {
     if (!this.disbled) {
         var pin = [
-                this.getFieldValue('DIN'), 
-                this.getFieldValue('CLK'), 
-                this.getFieldValue('CS'), 
-                this.getFieldValue('DC'), 
+                this.getFieldValue('DIN'),
+                this.getFieldValue('CLK'),
+                this.getFieldValue('CS'),
+                this.getFieldValue('DC'),
                 this.getFieldValue('RES')
         ];
         var devType = 'ssd1331';
@@ -3190,22 +3190,22 @@ Blockly.propc.oled_initialize = function () {
 
                 for (var k = 0; k < Blockly.getMainWorkspace().getAllBlocks().length; k++) {
                     var tempBlock = Blockly.getMainWorkspace().getAllBlocks()[k];
-                    
+
                     if (tempBlock.type === 'procedures_callnoreturn' && tempBlock.getRootBlock().type === 'cog_new') {
                         if (Blockly.propc.variableDB_.getName(((tempBlock.getFieldValue('NAME')).
                                 split('\u201C'))[1].slice(0, -1), Blockly.Procedures.NAME_TYPE) === myRootBlockName) {
                             cogStartBlock = myRootBlockName;
                         }
                     }
-                }    
+                }
             }
 
             if (cogStartBlock && isExperimental.indexOf('volatile') > -1) {  // Keep this experimental for now.
-                Blockly.propc.cog_setups_[this.myType] = [cogStartBlock, this.myType + ' = ' + 
+                Blockly.propc.cog_setups_[this.myType] = [cogStartBlock, this.myType + ' = ' +
                         devType + '_init(' + pin.join(', ') + devWidthHeight + ');'];
             } else {
                 Blockly.propc.setups_[this.myType] = this.myType + ' = ' + devType + '_init(' + pin.join(', ') + devWidthHeight + ');';
-            }         
+            }
         }
     }
     return '';
@@ -3248,9 +3248,9 @@ Blockly.Blocks.oled_clear_screen = {
         this.appendDummyInput()
                 .appendField(this.displayKind + " command")
                 .appendField(new Blockly.FieldDropdown([
-                        ["clear screen", "CLS"], 
-                        ["sleep", "SLEEP"], 
-                        ["wake", "WAKE"], 
+                        ["clear screen", "CLS"],
+                        ["sleep", "SLEEP"],
+                        ["wake", "WAKE"],
                         ["invert colors", "INV"],
                         ["normal colors", "NORMAL"],
                         ["orient pins up", "O-UP"],
@@ -3373,8 +3373,8 @@ Blockly.Blocks.oled_draw_circle = {
                     .appendField("color")
                     .setAlign(Blockly.ALIGN_RIGHT)
                     .appendField(new Blockly.FieldDropdown([
-                        ["black", "0"], 
-                        ["white", "1"], 
+                        ["black", "0"],
+                        ["white", "1"],
                         ["invert", "2"]
                     ]), 'COLOR_VALUE');
         }
@@ -3419,7 +3419,7 @@ Blockly.propc.oled_draw_circle = function () {
         if (this.getFieldValue('ck_fill') === 'TRUE') {
             code = 'fillCircle(' + this.myType + ', ';
         }
-        code += point_x0 + ', ' + point_y0 + ', ' + radius + ', ' + color + ');'; 
+        code += point_x0 + ', ' + point_y0 + ', ' + radius + ', ' + color + ');';
         return code;
     }
 };
@@ -3465,11 +3465,11 @@ Blockly.Blocks.oled_draw_line = {
                     .appendField("color")
                     .setAlign(Blockly.ALIGN_RIGHT)
                     .appendField(new Blockly.FieldDropdown([
-                        ["black", "0"], 
-                        ["white", "1"], 
+                        ["black", "0"],
+                        ["white", "1"],
                         ["invert", "2"]
                     ]), 'COLOR_VALUE');
-        }        
+        }
         this.setInputsInline(false);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
@@ -3539,11 +3539,11 @@ Blockly.Blocks.oled_draw_pixel = {
                     .appendField("color")
                     .setAlign(Blockly.ALIGN_RIGHT)
                     .appendField(new Blockly.FieldDropdown([
-                        ["black", "0"], 
-                        ["white", "1"], 
+                        ["black", "0"],
+                        ["white", "1"],
                         ["invert", "2"]
                     ]), 'COLOR_VALUE');
-        }        
+        }
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
@@ -3630,11 +3630,11 @@ Blockly.Blocks.oled_draw_triangle = {
                     .appendField("color")
                     .setAlign(Blockly.ALIGN_RIGHT)
                     .appendField(new Blockly.FieldDropdown([
-                        ["black", "0"], 
-                        ["white", "1"], 
+                        ["black", "0"],
+                        ["white", "1"],
                         ["invert", "2"]
                     ]), 'COLOR_VALUE');
-        }        
+        }
         this.appendDummyInput()
                 .setAlign(Blockly.ALIGN_RIGHT)
                 .appendField("fill")
@@ -3731,11 +3731,11 @@ Blockly.Blocks.oled_draw_rectangle = {
                     .appendField("color")
                     .setAlign(Blockly.ALIGN_RIGHT)
                     .appendField(new Blockly.FieldDropdown([
-                        ["black", "0"], 
-                        ["white", "1"], 
+                        ["black", "0"],
+                        ["white", "1"],
                         ["invert", "2"]
                     ]), 'COLOR_VALUE');
-        }        
+        }
         this.appendDummyInput()
                 .setAlign(Blockly.ALIGN_RIGHT)
                 .appendField("fill")
@@ -3783,7 +3783,7 @@ Blockly.propc.oled_draw_rectangle = function () {
         if (corners === '0') {
             code = code.replace(/RoundRect\(/g, 'Rect(');
         } else {
-            code += corners + ', ';            
+            code += corners + ', ';
         }
         return code + color + ');';
     }
@@ -3861,19 +3861,19 @@ Blockly.Blocks.oled_text_color = {
                     .appendField("ePaper font color        ")
                     .setAlign(Blockly.ALIGN_RIGHT)
                     .appendField(new Blockly.FieldDropdown([
-                        ["black", "0"], 
-                        ["white", "1"], 
+                        ["black", "0"],
+                        ["white", "1"],
                         ["invert", "2"]
                     ]), 'FONT_COLOR_VALUE');
             this.appendDummyInput('BACKGROUND_COLOR')
                     .appendField("font background color")
                     .setAlign(Blockly.ALIGN_RIGHT)
                     .appendField(new Blockly.FieldDropdown([
-                        ["black", "0"], 
-                        ["white", "1"], 
+                        ["black", "0"],
+                        ["white", "1"],
                         ["invert", "2"]
                     ]), 'BACKGROUND_COLOR_VALUE');
-        }        
+        }
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
         this.setWarningText(null);
@@ -3932,7 +3932,7 @@ Blockly.Blocks.oled_get_max_height = {
                 this.setTooltip(Blockly.MSG_OLED_GET_MAX_WIDTH_TOOLTIP.replace(/Display /, this.displayKind + ' '));
                 this.appendDummyInput()
                     .appendField(this.displayKind + ' max width');
-        } 
+        }
         this.setColour(colorPalette.getColor('protocols'));
         this.setPreviousStatement(false, null);
         this.setNextStatement(false, null);
@@ -4194,7 +4194,7 @@ Blockly.propc.oled_bitmap = function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
         if (allBlocks.toString().indexOf(this.displayKind + ' initialize') === -1) {
             return '// ERROR: ' + this.displayKind + ' is not initialized!\n';
-        }        
+        }
         for (var i = 0; i < allBlocks.length; i++) {
             if (allBlocks[i].type === 'sd_init') {
                 initFound = true;
@@ -4432,7 +4432,7 @@ Blockly.propc.ws2812b_set = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
     this.updateRGBpin();
 
-    if (allBlocks.toString().indexOf('RGB-LED initialize') === -1 && allBlocks.toString().indexOf('RGB-LED set number') === -1 && 
+    if (allBlocks.toString().indexOf('RGB-LED initialize') === -1 && allBlocks.toString().indexOf('RGB-LED set number') === -1 &&
             projectData && projectData['board'] !== 'heb-wx') {
         return '// ERROR: RGB-LED is not initialized!\n';
     }
@@ -4492,7 +4492,7 @@ Blockly.Blocks.ws2812b_set_multiple = {
 Blockly.propc.ws2812b_set_multiple = function () {
     this.updateRGBpin();
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (allBlocks.indexOf('RGB-LED initialize') === -1 && allBlocks.toString().indexOf('RGB-LED set number') && 
+    if (allBlocks.indexOf('RGB-LED initialize') === -1 && allBlocks.toString().indexOf('RGB-LED set number') &&
             projectData && projectData['board'] !== 'heb-wx') {
         return '// ERROR: RGB-LED is not initialized!\n';
     }
@@ -4581,8 +4581,8 @@ Blockly.Blocks.wx_init = {
                 .appendField('Simple WX initialize')
                 .appendField("mode")
                 .appendField(new Blockly.FieldDropdown([
-                        ['Terminal on USB', 'USB_PGM_TERM'], 
-                        ['Terminal on WX', 'USB_PGM'], 
+                        ['Terminal on USB', 'USB_PGM_TERM'],
+                        ['Terminal on WX', 'USB_PGM'],
                         ['Term & Programming on WX', 'WX_ALL_COM']
                     ], function (mode) {
                         if (mode === 'WX_ALL_COM') {
@@ -5067,8 +5067,8 @@ Blockly.Blocks.wx_init_adv = {
         this.appendDummyInput()
                 .appendField('WX initialize  mode')
                 .appendField(new Blockly.FieldDropdown([
-                    ['Terminal on USB', 'USB_PGM_TERM'], 
-                    ['Terminal on WX', 'USB_PGM'], 
+                    ['Terminal on USB', 'USB_PGM_TERM'],
+                    ['Terminal on WX', 'USB_PGM'],
                     ['Term & Programming on WX', 'WX_ALL_COM']
                 ], function (mode) {
                     if (mode === 'WX_ALL_COM') {
@@ -5310,7 +5310,7 @@ Blockly.Blocks.wx_scan_string = {
     domToMutation: function (container) {
         // Parse XML to restore the menu options.
         this.setPrefix_(container.getAttribute('prefix') || '');
-    },  
+    },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
         if (allBlocks.toString().indexOf('WX initialize') === -1 && projectData['board'] !== 'heb-wx')
@@ -6199,7 +6199,7 @@ Blockly.Blocks.graph_settings = {
         if (s.indexOf('FIXED') > -1) {
             this.addRanges(s);
         }
-        
+
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
         for (var j = 0; j < allBlocks.length; j++) {
             if (allBlocks[j].type === 'graph_output') {
@@ -6251,7 +6251,7 @@ Blockly.propc.graph_settings = function () {
 
         Blockly.propc.definitions_['graphing_settings'] = '// GRAPH_SETTINGS_START:100,' +
                 x_axis + ',' + modes[mode] + ',' + y_min + ',' + y_max;
-        
+
         if (modes[mode] === 'X') {
             var x_min = this.getFieldValue('XMIN') || '0';
             var x_max = this.getFieldValue('XMAX') || '0';
@@ -6424,7 +6424,7 @@ Blockly.Blocks.i2c_send = {
                 .appendField("data")
                 .appendField(new Blockly.FieldNumber('2', null, null, 1), "COUNT")
                 .appendField(new Blockly.FieldDropdown([
-                        ["bytes MSB first", "-1"], 
+                        ["bytes MSB first", "-1"],
                         ["bytes LSB first", "1"]
                     ]), "ORDER")
         this.appendValueInput("ADDR")
@@ -6563,7 +6563,7 @@ Blockly.propc.i2c_send = function () {
             }
         }
     }
-    
+
     if (!this.disabled) {
         var s1 = '';
         var s2 = '';
@@ -6636,7 +6636,7 @@ Blockly.Blocks.i2c_receive = {
                 .appendField("data")
                 .appendField(new Blockly.FieldNumber('2', null, null, 1), "COUNT")
                 .appendField(new Blockly.FieldDropdown([
-                        ["bytes MSB first", "-1"], 
+                        ["bytes MSB first", "-1"],
                         ["bytes LSB first", "1"]
                     ]), "ORDER")
         this.appendValueInput("ADDR")

--- a/src/editor.js
+++ b/src/editor.js
@@ -1809,7 +1809,7 @@ function RenderPageBrandingElements() {
     let appName = ApplicationName;
     let html = 'BlocklyProp<br><strong>' + ApplicationName + '</strong>';
 
-    if (window.location.hostname === product_banner_host_trigger) {
+    if (window.location.hostname === productBannerHostTrigger) {
         appName = TestApplicationName;
         html = 'BlocklyProp<br><strong>' + TestApplicationName + '</strong>';
         document.getElementById('nav-logo').style.backgroundImage = 'url(\'src/images/dev-toolkit.png\')';

--- a/src/globals.js
+++ b/src/globals.js
@@ -57,7 +57,7 @@ const TestApplicationName = "Solocup";
  *
  * @type {string}
  */
-const product_banner_host_trigger = 'solocup.parallax.com';
+const productBannerHostTrigger = 'solocup.parallax.com';
 
 
 /**
@@ -145,11 +145,11 @@ var pTerm;
 
 
 
-/**  WIP/TODO: generate svg icons and inject them (search for glyphicon and font-awesome and replace them).  
+/**  WIP/TODO: generate svg icons and inject them (search for glyphicon and font-awesome and replace them).
  *
  * These are string representations of inline SVG elements to be used as icons.
  * using JS to inject these into the HTML keeps the HTML simpler and cleaner.
- * 
+ *
  * @type {object}
  */
 const bpIcons = {

--- a/src/globals.js
+++ b/src/globals.js
@@ -21,7 +21,7 @@
  */
 
 /* Error logging */
-Sentry.init({ dsn: 'https://27707de6f602435b8c6bf1702efafd1d@sentry.io/2751639' });
+Sentry.init({dsn: 'https://27707de6f602435b8c6bf1702efafd1d@sentry.io/2751639'});
 
 
 /**
@@ -38,22 +38,30 @@ let projectData = null;
 
 /**
  * The application brand name in the production system
+ *
+ * TODO: Constant 'ApplicationName' is moving to ./modules/constants.js
+ *
  * @type {string}
  */
-const ApplicationName = "Solo";
+const ApplicationName = 'Solo';
 
 
 /**
  * The application brand name as used in the Test system
+ *
+ * TODO: Constant 'TestApplicationName' is moving to ./modules/constants.js
+ *
  * @type {string}
  */
-const TestApplicationName = "Solocup";
+const TestApplicationName = 'Solocup';
 
 
 /**
  * This is the name of the test ECS cluster. A matching hostname will
  * trigger a few UI changes to visually confirm that the visitor has reached
  * the test site.
+ *
+ * TODO: Constant 'productBannerHostTrigger' is moving to ./modules/constants.js
  *
  * @type {string}
  */

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@
  * Display the BlocklyProp Solo license in a modal window
  */
 function showLicense() {
-    $('#licenseModal').modal();
+  $('#licenseModal').modal();
 }
 
 
@@ -33,11 +33,11 @@ function showLicense() {
  * Display the application name
  */
 function showAppName() {
-    let html = 'BlocklyProp<br><strong>Solo</strong>';
-    if (window.location.hostname === product_banner_host_trigger) {
-        html = 'BlocklyProp<br><strong>' + TestApplicationName + '</strong>';
-    }
-    $('#nav-logo').html(html);
+  let html = 'BlocklyProp<br><strong>Solo</strong>';
+  if (window.location.hostname === productBannerHostTrigger) {
+    html = 'BlocklyProp<br><strong>' + TestApplicationName + '</strong>';
+  }
+  $('#nav-logo').html(html);
 }
 
 
@@ -46,10 +46,11 @@ function showAppName() {
  * @param {string} appName
  */
 function showAppBannerTitle(appName) {
-    $('#app-banner-title').html('BlocklyProp ' + appName);
-    if (window.location.hostname === product_banner_host_trigger) {
-        document.getElementById('nav-logo').style.backgroundImage = 'url(\'src/images/dev-toolkit.png\')';
-    }
+  $('#app-banner-title').html('BlocklyProp ' + appName);
+  if (window.location.hostname === productBannerHostTrigger) {
+    document.getElementById('nav-logo')
+        .style.backgroundImage = 'url(\'src/images/dev-toolkit.png\')';
+  }
 }
 
 
@@ -58,14 +59,14 @@ function showAppBannerTitle(appName) {
  * @param {HTMLElement} element
  */
 function setCopyrightDate(element) {
-    let d = new Date();
-    element.innerHTML = d.getFullYear().toString();
+  const d = new Date();
+  element.innerHTML = d.getFullYear().toString();
 }
 
 
 let appName = ApplicationName;
-if (window.location.hostname === product_banner_host_trigger) {
-    appName = TestApplicationName;
+if (window.location.hostname === productBannerHostTrigger) {
+  appName = TestApplicationName;
 }
 
 showAppName();
@@ -77,9 +78,9 @@ setCopyrightDate(document.getElementById('license-copyright-date'));
 // The browser localStorage object should be empty
 window.localStorage.clear();
 
-// If the experimental URL parameter is used, add it to the open and new project links
+// Add experimental URL parameter to the open and new project links, if used
 if (window.getURLParameter('experimental')) {
-  $('.editor-link').attr('href', function () {
+  $('.editor-link').attr('href', function() {
     return this + window.getAllURLParameters().replace('?', '&');
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,37 +21,17 @@
  */
 
 
-// Update page elements
-// This construct replaces the document.ready() that was
-// deprecated in jquery 1.9
-$(function () {
-    let appName = ApplicationName;
-    if (window.location.hostname === product_banner_host_trigger) {
-        appName = TestApplicationName;
-    }
-
-    showAppName();
-    showAppBannerTitle(appName);
-    setCopyrightDate($('#footer_copyright'));
-    setCopyrightDate($('#license-copyright-date'));
-
-    // The browser localStorage object should be empty
-    window.localStorage.clear();
-
-    // If the experimental URL parameter is used, add it to the open and new project links
-    if (window.getURLParameter('experimental')) {
-        $('.editor-link').attr('href', function () {
-            return this + window.getAllURLParameters().replace('?', '&');
-        });
-    }
-});
-
-// Display the BlocklyProp Solo license in a modal window
+/**
+ * Display the BlocklyProp Solo license in a modal window
+ */
 function showLicense() {
     $('#licenseModal').modal();
 }
 
-// Display the application name
+
+/**
+ * Display the application name
+ */
 function showAppName() {
     let html = 'BlocklyProp<br><strong>Solo</strong>';
     if (window.location.hostname === product_banner_host_trigger) {
@@ -61,7 +41,10 @@ function showAppName() {
 }
 
 
-// Display the app name in the banner
+/**
+ * Display the app name in the banner
+ * @param {string} appName
+ */
 function showAppBannerTitle(appName) {
     $('#app-banner-title').html('BlocklyProp ' + appName);
     if (window.location.hostname === product_banner_host_trigger) {
@@ -69,8 +52,35 @@ function showAppBannerTitle(appName) {
     }
 }
 
-// Set the ending copyright date
+
+/**
+ * Set the ending copyright date
+ * @param {HTMLElement} element
+ */
 function setCopyrightDate(element) {
     let d = new Date();
-    element.html(d.getFullYear().toString());
+    element.innerHTML = d.getFullYear().toString();
 }
+
+
+let appName = ApplicationName;
+if (window.location.hostname === product_banner_host_trigger) {
+    appName = TestApplicationName;
+}
+
+showAppName();
+showAppBannerTitle(appName);
+setCopyrightDate(document.getElementById('footer_copyright'));
+setCopyrightDate(document.getElementById('license-copyright-date'));
+
+
+// The browser localStorage object should be empty
+window.localStorage.clear();
+
+// If the experimental URL parameter is used, add it to the open and new project links
+if (window.getURLParameter('experimental')) {
+  $('.editor-link').attr('href', function () {
+    return this + window.getAllURLParameters().replace('?', '&');
+  });
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -84,3 +84,5 @@ if (window.getURLParameter('experimental')) {
   });
 }
 
+// Display the license in a modal when the link is clicked
+$('#show_license').on('click', () => showLicense());

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -1,0 +1,47 @@
+/*
+ *   TERMS OF USE: MIT License
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a
+ *   copy of this software and associated documentation files (the "Software"),
+ *   to deal in the Software without restriction, including without limitation
+ *   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *   and/or sell copies of the Software, and to permit persons to whom the
+ *   Software is furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL
+ *   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *   DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * This is the name of the test ECS cluster. A matching hostname will
+ * trigger a few UI changes to visually confirm that the visitor has reached
+ * the test site.
+ *
+ * @type {string}
+ */
+const productBannerHostTrigger = 'solocup.parallax.com';
+
+
+/**
+ * The application brand name in the production system
+ * @type {string}
+ */
+const ApplicationName = 'Solo';
+
+
+/**
+ * The application brand name as used in the Test system
+ * @type {string}
+ */
+const TestApplicationName = 'Solocup';
+
+
+export {ApplicationName, productBannerHostTrigger, TestApplicationName};

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -20,6 +20,11 @@
  *   DEALINGS IN THE SOFTWARE.
  */
 
+import {
+  ApplicationName,
+  productBannerHostTrigger,
+  TestApplicationName} from './constants.js';
+
 
 /**
  * Display the BlocklyProp Solo license in a modal window
@@ -81,7 +86,8 @@ window.localStorage.clear();
 // Add experimental URL parameter to the open and new project links, if used
 if (window.getURLParameter('experimental')) {
   $('.editor-link').attr('href', function() {
-    return this + window.getAllURLParameters().replace('?', '&');
+    return document.location.href +
+        window.getAllURLParameters().replace('?', '&');
   });
 }
 


### PR DESCRIPTION
This update refactors the entire home page to use ES6 modules. The src/modules directory contains all JavaScript modules used in the project.

The ESLint configuration has been updated to continue linting all ./src file except those in the ./src/modules tree. There is a special override in the configuration to treat all .js files under the ./src/modules tree as JavsScript modules. Furthermore, the linter is now using the somewhat more stringent [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html). There will be a transition period where most of the issues raised will be converted to warnings. 
