### PR TITLE
More refactoring to eliminate globals

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -74,10 +74,13 @@
 * Blockly.propc.heb_text_to_speech_say
 * Blockly.propc.heb_text_to_speech_spell
 
-
 ### procedures.js
 * Blockly.Blocks['procedures_callnoreturn']
 * Blockly.Blocks['procedures_defnoreturn']
+
+### propc.js
+* Blockly.propc.finish
+* Blockly.propc.init
 
 ### s3.js
 * Blockly.Blocks.analog_input

--- a/src/blockly/generators/field_ace.js
+++ b/src/blockly/generators/field_ace.js
@@ -23,7 +23,7 @@
 /**
  * @fileoverview Code input field.
  * @author matt.m.matz@gmail.com (Matthew Matz)
- * 
+ *
  * Based on custom field examples written by Beka Westberg
  * https://github.com/BeksOmega/BlocklySummit2019-Fields
  */
@@ -37,6 +37,7 @@ goog.require('Blockly.utils.dom');
 
 /**
  * Class for a field used to edit custom code.
+ * @param {string} displayText
  * @param {string=} opt_value text or code to initially start with in the editor.
  * @param {Function=} opt_validator A function that is called to validate
  *    changes to the field's value.
@@ -50,6 +51,7 @@ Blockly.FieldAceEditor = function(displayText, opt_value, opt_validator) {
   }
   Blockly.FieldAceEditor.superClass_.constructor.call(this, opt_value, opt_validator);
 };
+
 goog.inherits(Blockly.FieldAceEditor, Blockly.Field);
 
 /**
@@ -84,10 +86,10 @@ Blockly.FieldAceEditor.prototype.doClassValidation_ = function(newValue) {
  * Render the on-block display. And rerender the editor if it is open.
  * @protected
  */
-Blockly.FieldAceEditor.prototype.render_ = function() {  
+Blockly.FieldAceEditor.prototype.render_ = function() {
   if (!this.arrowRendered_) {
     this.arrowRendered_ = true;
-    var span = Blockly.utils.dom.createSvgElement('tspan', {}, null);
+    const span = Blockly.utils.dom.createSvgElement('tspan', {}, null);
     this.arrow_ = document.createTextNode(' \u25BE');
     span.appendChild(this.arrow_);
     span.style['fill'] = this.sourceBlock_.getColour();
@@ -119,7 +121,7 @@ Blockly.FieldAceEditor.prototype.getDisplayText_ = function() {
  */
 Blockly.FieldAceEditor.prototype.showEditor_ = function() {
   this.editor_ = this.dropdownCreate_();
-  var currentField = this;
+  const currentField = this;
   this.codeField_ = ace.edit(this.editor_);
   this.codeField_.setTheme("ace/theme/chrome");
   this.codeField_.getSession().setMode("ace/mode/c_cpp");
@@ -143,10 +145,11 @@ Blockly.FieldAceEditor.prototype.showEditor_ = function() {
  * @private
  */
 Blockly.FieldAceEditor.prototype.dropdownCreate_ = function() {
-  var editorDiv = document.createElement('div');
+  const editorDiv = document.createElement('div');
   editorDiv.style.width = '400px';
   editorDiv.style.height = '250px';
 
+  // TODO: Returning an HTMLDivElement but a HTMLObjectElement was specified.
   return editorDiv;
 };
 

--- a/src/blockly/generators/propc.js
+++ b/src/blockly/generators/propc.js
@@ -26,8 +26,17 @@
  */
 'use strict';
 
-var array_contains = function (haystack, needle) {
-    for (var straw = 0; straw < haystack.length; straw++) {
+
+/**
+ * Looks for a needle in a haystack. That's all we know.
+ * @param {Array} haystack
+ * @param {string} needle
+ * @return {null|number}
+ *
+ * @deprecated This appears to be an abandoned function
+ */
+const array_contains = function (haystack, needle) {
+    for (let straw = 0; straw < haystack.length; straw++) {
         if (haystack[straw] === needle) {
             return straw;
         }
@@ -39,7 +48,7 @@ var array_contains = function (haystack, needle) {
  * Color Palette - Created by Michel on 30-4-2016.
  */
 
-var colorPalette = {
+const colorPalette = {
     defaultColors: {
         'input': 140,
         'output': 165,
@@ -77,8 +86,8 @@ var colorPalette = {
         }
         return '#000000';
     }
-
 };
+
 
 if (document.referrer.indexOf('?') === -1) {
     colorPalette.activePalette = colorPalette.defaultColors;
@@ -132,6 +141,7 @@ Blockly.propc.ORDER_NONE = 99; // (...)
  * propc Board profiles
  *
  */
+/*
 var profile = {
     "activity-board": {
         description: "Propeller Activity Board",
@@ -205,14 +215,15 @@ var profile = {
         saves_to: []
     }
 };
-
+*/
 
 /**
  * Initialize the database of variable names.
  * @param {workspace} workspace The active workspace.
  */
 Blockly.propc.init = function (workspace) {
-// Create a dictionary of definitions to be printed before setups.
+    const profile = window.projectProfile;
+    // Create a dictionary of definitions to be printed before setups.
     Blockly.propc.definitions_ = {};
     Blockly.propc.definitions_["include simpletools"] = '#include "simpletools.h"';
     Blockly.propc.methods_ = {};
@@ -228,12 +239,12 @@ Blockly.propc.init = function (workspace) {
     Blockly.propc.string_var_lengths = [];
 
     // Set up specific libraries for devices like the Scribbler or Badge
-    if (profile.default.description === "Scribbler Robot") {
+    if (profile.description === "Scribbler Robot") {
         Blockly.propc.definitions_[ "include_scribbler" ] = '#include "s3.h"';
-    } else if (profile.default.description === "Hackable Electronic Badge") {
+    } else if (profile.description === "Hackable Electronic Badge") {
         Blockly.propc.definitions_["badgetools"] = '#include "badgetools.h"';
         Blockly.propc.setups_["badgetools"] = 'badge_setup();';
-    } else if (profile.default.description === "Badge WX") {
+    } else if (profile.description === "Badge WX") {
         Blockly.propc.definitions_["badgetools"] = '#include "badgewxtools.h"';
         Blockly.propc.setups_["badgetools"] = 'badge_setup();';
     }
@@ -267,6 +278,7 @@ Blockly.propc.init = function (workspace) {
  * @return {string} Completed code.
  */
 Blockly.propc.finish = function (code) {
+    const profile = window.projectProfile;
     // Convert the definitions dictionary into a list.
     var imports = [];
     var methods = [];
@@ -372,9 +384,7 @@ Blockly.propc.finish = function (code) {
                 function_vars.push(definitions[def]);
             }
         }
-
     }
-
 
     for (var stack in Blockly.propc.stacks_) {
         definitions.push(Blockly.propc.stacks_[stack]);
@@ -386,7 +396,7 @@ Blockly.propc.finish = function (code) {
     for (var name in Blockly.propc.setups_)
         setups.push('  ' + Blockly.propc.setups_[name]);
 
-    if (profile.default.description === "Scribbler Robot")
+    if (profile.description === "Scribbler Robot")
         setups.unshift('  s3_setup();pause(100);');
 
     // Add volatile to variable declarations in cogs
@@ -432,7 +442,7 @@ Blockly.propc.finish = function (code) {
         code = 'int main()\n{\n' + setups.join('\n') + '\n' + code + '\n}';
         var setup = '';
         if (Blockly.mainWorkspace.getAllBlocks().length === 0 &&
-                profile.default.description !== "Propeller C (code-only)") {
+                profile.description !== "Propeller C (code-only)") {
             setup += "/* EMPTY_PROJECT */\n";
         }
         setup += ui_system_settings.join('\n') + '\n\n';

--- a/src/blockly/generators/propc/communicate.js
+++ b/src/blockly/generators/propc/communicate.js
@@ -32,7 +32,6 @@
 
 'use strict';
 
-//define blocks
 if (!Blockly.Blocks)
     Blockly.Blocks = {};
 
@@ -675,12 +674,15 @@ Blockly.propc.console_print_multiple = function () {
         case 'serial_print_multiple':
             initBlock = 'Serial initialize';
             errorString = '// ERROR: Serial is not initialized!\n';
+            // TODO: Variable is declared in one case and then used in another case.
             var p = '';
             if (this.ser_pins.length > 0) {
                 p = this.ser_pins[0].replace(',', '_').replace(/None/g, 'N');
             }
             if (this.getInput('SERPIN')) {
-                p = this.getFieldValue('SER_PIN').replace(',', '_').replace(/None/g, 'N');
+                p = this.getFieldValue('SER_PIN')
+                    .replace(',', '_')
+                    .replace(/None/g, 'N');
             }
             code += 'dprint(fdser' + p + ', "';
             break;
@@ -713,17 +715,23 @@ Blockly.propc.console_print_multiple = function () {
             code += 'oledprint("';
             break;
         case 'string_sprint_multiple':
-            p = Blockly.propc.variableDB_.getName(this.getFieldValue('VAR'), Blockly.Variables.NAME_TYPE);
+            // TODO: Blockly.Variables.NAME_TYPE is deprecated.
+            p = Blockly.propc.variableDB_.getName(
+                this.getFieldValue('VAR'), Blockly.Variables.NAME_TYPE);
             Blockly.propc.vartype_[p] = 'char *';
             code += 'sprint(' + p + ', "';
             break;
         case 'wx_print_multiple':
             initBlock = 'WX initialize';
             errorString = '// ERROR: WX is not initialized!\n';
-            if (projectData && projectData.board === 'heb-wx') {
+
+            //if (window.project.boardType.name === 'heb-wx') {
+            if (window.project.boardType.name === 'heb-wx') {
                 initBlock = null;
             }
-            var handle = Blockly.propc.variableDB_.getName(this.getFieldValue('HANDLE'), Blockly.Variables.NAME_TYPE);
+            // TODO: Blockly.Variables.NAME_TYPE is deprecated.
+            var handle = Blockly.propc.variableDB_.getName(
+                this.getFieldValue('HANDLE'), Blockly.Variables.NAME_TYPE);
             var conn = this.getFieldValue('CONNECTION');
             code += 'wifi_print(' + conn + ', ' + handle + ', "';
             break;
@@ -761,9 +769,15 @@ Blockly.propc.console_print_multiple = function () {
         }
 
         if (!this.getFieldValue('TYPE' + i).includes('float point  divide by')) {
-            varList += ', ' + (Blockly.propc.valueToCode(this, 'PRINT' + i, Blockly.propc.ORDER_NONE).replace(/%/g, '%%') || orIt);
+            varList += ', ' + (Blockly.propc.valueToCode(
+                this,
+                'PRINT' + i,
+                Blockly.propc.ORDER_NONE).replace(/%/g, '%%') || orIt);
         } else {
-            varList += ', ((float) ' + (Blockly.propc.valueToCode(this, 'PRINT' + i, Blockly.propc.ORDER_NONE) || orIt) +
+            varList += ', ((float) ' + (Blockly.propc.valueToCode(
+                this,
+                'PRINT' + i,
+                Blockly.propc.ORDER_NONE) || orIt) +
                     ') / ' + this.getFieldValue('DIV' + i) + '.0';
         }
         i++;
@@ -773,7 +787,8 @@ Blockly.propc.console_print_multiple = function () {
     }
     code += '"' + varList + ');\n';
 
-    var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
+    // TODO: Replace .getAllBlocks() with getAllBlocksByType()
+    var allBlocks = Blockly.getMainWorkspace().getAllBlocks(false).toString();
     if (initBlock && allBlocks.indexOf(initBlock) === -1) {
         code = errorString;
     }
@@ -781,7 +796,7 @@ Blockly.propc.console_print_multiple = function () {
         code = '// ERROR: You cannot use Advanced WX blocks with Simple WX blocks!';
     }
 
-    if (projectData.board === 'heb-wx' && this.type === 'wx_print_multiple') {
+    if (window.project.boardType.name === 'heb-wx' && this.type === 'wx_print_multiple') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
@@ -814,7 +829,9 @@ Blockly.Blocks.console_scan_text = {
  * @returns {string}
  */
 Blockly.propc.console_scan_text = function () {
-    var data = Blockly.propc.variableDB_.getName(this.getFieldValue('VALUE'), Blockly.Variables.NAME_TYPE);
+    // TODO: Blockly.Variables.NAME_TYPE is deprecated.
+    var data = Blockly.propc.variableDB_.getName(
+        this.getFieldValue('VALUE'), Blockly.Variables.NAME_TYPE);
     Blockly.propc.vartype_[data] = 'char *';
 
     if (data !== '') {
@@ -4255,7 +4272,7 @@ Blockly.Blocks.ws2812b_init = {
         const profile = window.projectProfile;
         var myTooltip = Blockly.MSG_WS2812B_INIT_TOOLTIP;
         var myHelpUrl = Blockly.MSG_WS2812B_HELPURL;
-        if (projectData && projectData['board'] === 'heb-wx') {
+        if (window.project.boardType.name === 'heb-wx') {
             myTooltip = Blockly.MSG_BADGE_RGB_INIT_TOOLTIP;
             myHelpUrl = Blockly.MSG_WS2812B_HELPURL;
         }
@@ -4265,7 +4282,7 @@ Blockly.Blocks.ws2812b_init = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
         this.setColour(colorPalette.getColor('protocols'));
-        if (projectData && projectData['board'] === 'heb-wx') {
+        if (window.project.boardType.name === 'heb-wx') {
             this.appendDummyInput()
                     .appendField("RGB-LED set number of LEDs")
                     .appendField(new Blockly.FieldNumber(
@@ -4318,7 +4335,7 @@ Blockly.Blocks.ws2812b_init = {
 Blockly.propc.ws2812b_init = function () {
     if (!this.disabled) {
         var pin = '';
-        if (projectData && projectData['board'] !== 'heb-wx') {
+        if (window.project.boardType.name !== 'heb-wx') {
             pin = this.getFieldValue('PIN');
         }
         var num = window.parseInt(this.getFieldValue('LEDNUM')) || '4';
@@ -4330,7 +4347,7 @@ Blockly.propc.ws2812b_init = function () {
 
         Blockly.propc.definitions_["ws2812b_def"] = '#include "ws2812.h"';
         Blockly.propc.definitions_["ws2812b_sets" + pin] = '';
-        if (projectData && projectData['board'] !== 'heb-wx') {
+        if (window.project.boardType.name !== 'heb-wx') {
             Blockly.propc.definitions_["ws2812b_sets" + pin] += '#define RGB_PIN' + pin + '   ' + pin;
         }
         Blockly.propc.definitions_["ws2812b_sets" + pin] += '\n#define RGB_COUNT' + pin + '   ' + num;
@@ -4343,7 +4360,7 @@ Blockly.propc.ws2812b_init = function () {
 Blockly.Blocks.ws2812b_set = {
     init: function () {
         var myHelpUrl = Blockly.MSG_WS2812B_HELPURL;
-        if (projectData && projectData['board'] === 'heb-wx') {
+        if (window.project.boardType.name === 'heb-wx') {
             myHelpUrl = Blockly.MSG_BADGE_LEDS_HELPURL;
         }
         this.setHelpUrl(myHelpUrl);
@@ -4361,7 +4378,7 @@ Blockly.Blocks.ws2812b_set = {
         this.setWarningText(null);
         this.rgb_pins = [];
         this.warnFlag = 0;
-        if (projectData && projectData['board'] !== 'heb-wx') {
+        if (window.project.boardType.name !== 'heb-wx') {
             this.rgbPins();
         }
     },
@@ -4439,10 +4456,13 @@ Blockly.Blocks.ws2812b_set = {
     },
     onchange: function (event) {
         // Don't fire if BadgeWX
-        if (event && projectData && projectData['board'] !== 'heb-wx') {
+        if (event && window.project.boardType.name !== 'heb-wx') {
 
             // only fire when a block got deleted or created, the RGB_PIN field was changed
-            if (event.type == Blockly.Events.BLOCK_CREATE || event.type == Blockly.Events.BLOCK_DELETE || (event.name === 'RGB_PIN' && event.blockId === this.id) || this.warnFlag > 0) {
+            if (event.type == Blockly.Events.BLOCK_CREATE ||
+                event.type == Blockly.Events.BLOCK_DELETE ||
+                (event.name === 'RGB_PIN' && event.blockId === this.id) ||
+                this.warnFlag > 0) {
                 var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
                 if (allBlocks.toString().indexOf('RGB-LED initialize') === -1)
                 {
@@ -4474,7 +4494,7 @@ Blockly.propc.ws2812b_set = function () {
     this.updateRGBpin();
 
     if (allBlocks.toString().indexOf('RGB-LED initialize') === -1 && allBlocks.toString().indexOf('RGB-LED set number') === -1 &&
-            projectData && projectData['board'] !== 'heb-wx') {
+        window.project.boardType.name !== 'heb-wx') {
         return '// ERROR: RGB-LED is not initialized!\n';
     }
 
@@ -4482,7 +4502,7 @@ Blockly.propc.ws2812b_set = function () {
     var color = Blockly.propc.valueToCode(this, 'COLOR', Blockly.propc.ORDER_NONE) || '0x555555' ;
 
     var p = '0';
-    if (projectData && projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         p = '';
     } else {
         if (this.rgb_pins.length > 0) {
@@ -4499,7 +4519,7 @@ Blockly.propc.ws2812b_set = function () {
 Blockly.Blocks.ws2812b_set_multiple = {
     init: function () {
         var myHelpUrl = Blockly.MSG_WS2812B_HELPURL;
-        if (projectData && projectData['board'] === 'heb-wx') {
+        if (window.project.boardType.name === 'heb-wx') {
             myHelpUrl = Blockly.MSG_BADGE_LEDS_HELPURL;
         }
         this.setHelpUrl(myHelpUrl);
@@ -4519,7 +4539,7 @@ Blockly.Blocks.ws2812b_set_multiple = {
         this.setNextStatement(true, null);
         this.setWarningText(null);
         this.rgb_pins = [];
-        if (projectData && projectData['board'] !== 'heb-wx') {
+        if (window.project.boardType.name !== 'heb-wx') {
             this.rgbPins();
         }
     },
@@ -4534,7 +4554,7 @@ Blockly.propc.ws2812b_set_multiple = function () {
     this.updateRGBpin();
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
     if (allBlocks.indexOf('RGB-LED initialize') === -1 && allBlocks.toString().indexOf('RGB-LED set number') &&
-            projectData && projectData['board'] !== 'heb-wx') {
+        window.project.boardType.name !== 'heb-wx') {
         return '// ERROR: RGB-LED is not initialized!\n';
     }
 
@@ -4542,7 +4562,7 @@ Blockly.propc.ws2812b_set_multiple = function () {
     var end = Blockly.propc.valueToCode(this, 'END', Blockly.propc.ORDER_NONE);
     var color = Blockly.propc.valueToCode(this, 'COLOR', Blockly.propc.ORDER_NONE) || '0x555555';
     var p = '0';
-    if (projectData && projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         p = '';
     } else {
         if (this.rgb_pins.length > 0) {
@@ -4561,7 +4581,7 @@ Blockly.propc.ws2812b_set_multiple = function () {
 Blockly.Blocks.ws2812b_update = {
     init: function () {
         var myHelpUrl = Blockly.MSG_WS2812B_HELPURL;
-        if (projectData && projectData['board'] === 'heb-wx') {
+        if (window.project.boardType.name === 'heb-wx') {
             myHelpUrl = Blockly.MSG_BADGE_LEDS_HELPURL;
         }
         this.setHelpUrl(myHelpUrl);
@@ -4574,7 +4594,7 @@ Blockly.Blocks.ws2812b_update = {
         this.setWarningText(null);
         this.rgb_pins = [];
         this.setColour(colorPalette.getColor('protocols'));
-        if (projectData && projectData['board'] !== 'heb-wx') {
+        if (window.project.boardType.name !== 'heb-wx') {
             this.rgbPins();
         }
     },
@@ -4589,7 +4609,7 @@ Blockly.propc.ws2812b_update = function () {
     this.updateRGBpin();
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
     if (allBlocks.indexOf('RGB-LED initialize') === -1 && allBlocks.toString().indexOf('RGB-LED set number')) {
-        if (projectData && projectData['board'] !== 'heb-wx') {
+        if (window.project.boardType.name !== 'heb-wx') {
             return '// ERROR: RGB-LED is not initialized!\n';
         } else if (!this.disabled) {
             Blockly.propc.definitions_["ws2812b_def"] = '#include "ws2812.h"';
@@ -4599,7 +4619,7 @@ Blockly.propc.ws2812b_update = function () {
         }
     }
     var p = '';
-    if (projectData && projectData['board'] !== 'heb-wx') {
+    if (window.project.boardType.name !== 'heb-wx') {
         if (this.rgb_pins.length > 0) {
             p = this.rgb_pins[0];
         }
@@ -4720,8 +4740,9 @@ Blockly.Blocks.wx_config_page = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
-        {
+        if (allBlocks.toString()
+            .indexOf('Simple WX initialize') === -1 &&
+            window.project.boardType.name !== 'heb-wx') {
             this.setWarningText('WARNING: You must use a Simple WX\ninitialize block at the beginning of your program!');
         } else {
             var warnTxt = null;
@@ -4737,10 +4758,11 @@ Blockly.Blocks.wx_config_page = {
 
 Blockly.propc.wx_config_page = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
     }
-    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+        window.project.boardType.name !== 'heb-wx')
     {
         return '// ERROR: Simple WX is not initialized!\n';
     } else {
@@ -4793,7 +4815,8 @@ Blockly.Blocks.wx_set_widget = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+        if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+            window.project.boardType.name !== 'heb-wx')
         {
             this.setWarningText('WARNING: You must use a Simple WX\ninitialize block at the beginning of your program!');
         } else {
@@ -4916,10 +4939,11 @@ Blockly.Blocks.wx_set_widget = {
 
 Blockly.propc.wx_set_widget = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
     }
-    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+        window.project.boardType.name !== 'heb-wx')
     {
         return '// ERROR: Simple WX is not initialized!\n';
     } else {
@@ -4968,10 +4992,11 @@ Blockly.Blocks.wx_send_widget = {
 
 Blockly.propc.wx_send_widget = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
     }
-    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+        window.project.boardType.name !== 'heb-wx')
     {
         return '// ERROR: Simple WX is not initialized!\n';
     } else {
@@ -5000,10 +5025,11 @@ Blockly.Blocks.wx_read_widgets = {
 
 Blockly.propc.wx_read_widgets = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
     }
-    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+        window.project.boardType.name !== 'heb-wx')
     {
         return '// ERROR: Simple WX is not initialized!\n';
     } else {
@@ -5041,10 +5067,11 @@ Blockly.Blocks.wx_get_widget = {
 
 Blockly.propc.wx_get_widget = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
     }
-    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+        window.project.boardType.name !== 'heb-wx')
     {
         return '// ERROR: Simple WX is not initialized!\n';
     } else {
@@ -5071,10 +5098,11 @@ Blockly.Blocks.wx_evt_connected = {
 
 Blockly.propc.wx_evt_connected = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
     }
-    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+        window.project.boardType.name !== 'heb-wx')
     {
         return '// ERROR: Simple WX is not initialized!\n';
     } else {
@@ -5098,10 +5126,11 @@ Blockly.Blocks.wx_reconnect = {
 
 Blockly.propc.wx_reconnect = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
     }
-    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+    if (allBlocks.toString().indexOf('Simple WX initialize') === -1 &&
+        window.project.boardType.name !== 'heb-wx')
     {
         return '// ERROR: Simple WX is not initialized!\n';
     } else {
@@ -5246,7 +5275,8 @@ Blockly.Blocks.wx_scan_multiple = {
     updateSerPin: function () {},
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        if (allBlocks.toString().indexOf('WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+        if (allBlocks.toString().indexOf('WX initialize') === -1 &&
+            window.project.boardType.name !== 'heb-wx')
         {
             this.setWarningText('WARNING: You must use a WX\ninitialize block at the beginning of your program!');
         } else {
@@ -5266,11 +5296,12 @@ Blockly.Blocks.wx_scan_multiple = {
 
 Blockly.propc.wx_scan_multiple = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.toString().indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx')
+    if (allBlocks.toString().indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx')
     {
         var handle = Blockly.propc.variableDB_.getName(this.getFieldValue('HANDLE'), Blockly.Variables.NAME_TYPE);
         var conn = this.getFieldValue('CONNECTION');
@@ -5386,7 +5417,8 @@ Blockly.Blocks.wx_scan_string = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        if (allBlocks.toString().indexOf('WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+        if (allBlocks.toString().indexOf('WX initialize') === -1 &&
+            window.project.boardType.name !== 'heb-wx')
         {
             this.setWarningText('WARNING: You must use a WX\ninitialize block at the beginning of your program!');
         } else {
@@ -5416,11 +5448,12 @@ Blockly.Blocks.wx_scan_string = {
 
 Blockly.propc.wx_scan_string = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx'))
+    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx'))
     {
         var handle = Blockly.propc.variableDB_.getName(this.getFieldValue('HANDLE'), Blockly.Variables.NAME_TYPE);
         var conn = this.getFieldValue('CONNECTION');
@@ -5462,11 +5495,12 @@ Blockly.Blocks.wx_send_string = {
 
 Blockly.propc.wx_send_string = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx'))
+    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx'))
     {
         var data = Blockly.propc.valueToCode(this, 'DATA', Blockly.propc.ORDER_NONE);
         var handle = Blockly.propc.variableDB_.getName(this.getFieldValue('HANDLE'), Blockly.Variables.NAME_TYPE);
@@ -5505,11 +5539,12 @@ Blockly.Blocks.wx_receive_string = {
 
 Blockly.propc.wx_receive_string = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx'))
+    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx'))
     {
         var data = Blockly.propc.variableDB_.getName(this.getFieldValue('DATA'), Blockly.Variables.NAME_TYPE);
         var handle = Blockly.propc.variableDB_.getName(this.getFieldValue('HANDLE'), Blockly.Variables.NAME_TYPE);
@@ -5545,18 +5580,18 @@ Blockly.Blocks.wx_poll = {
 
 Blockly.propc.wx_poll = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx'))
+    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx'))
     {
         var id = Blockly.propc.variableDB_.getName(this.getFieldValue('ID'), Blockly.Variables.NAME_TYPE);
         var event = Blockly.propc.variableDB_.getName(this.getFieldValue('EVENT'), Blockly.Variables.NAME_TYPE);
         var handle = Blockly.propc.variableDB_.getName(this.getFieldValue('HANDLE'), Blockly.Variables.NAME_TYPE);
 
-        var code = 'wifi_poll(&' + event + ', &' + id + ', &' + handle + ');\n';
-        return code;
+        return 'wifi_poll(&' + event + ', &' + id + ', &' + handle + ');\n';
     } else {
         return '// ERROR: WX is not initialized!\n';
     }
@@ -5640,11 +5675,12 @@ Blockly.Blocks.wx_listen = {
 
 Blockly.propc.wx_listen = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx'))
+    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx'))
     {
         var path = Blockly.propc.valueToCode(this, 'PATH', Blockly.propc.ORDER_NONE);
         var protocol = this.getFieldValue('PROTOCOL');
@@ -5680,7 +5716,8 @@ Blockly.Blocks.wx_join = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        if (allBlocks.toString().indexOf('WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+        if (allBlocks.toString().indexOf('WX initialize') === -1 &&
+            window.project.boardType.name !== 'heb-wx')
         {
             this.setWarningText('WARNING: You must use a WX\ninitialize block at the beginning of your program!');
         } else {
@@ -5691,11 +5728,12 @@ Blockly.Blocks.wx_join = {
 
 Blockly.propc.wx_join = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx')
+    if (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx')
     {
         var ssid = this.getFieldValue('SSID') || '';
         var pass = this.getFieldValue('PASS') || '';
@@ -5833,7 +5871,7 @@ Blockly.Blocks.wx_mode = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        if (allBlocks.toString().indexOf('WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+        if (allBlocks.toString().indexOf('WX initialize') === -1 && window.project.boardType.name !== 'heb-wx')
         {
             this.setWarningText('WARNING: You must use a WX\ninitialize block at the beginning of your program!');
         }
@@ -5842,11 +5880,12 @@ Blockly.Blocks.wx_mode = {
 
 Blockly.propc.wx_mode = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx')
+    if (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx')
     {
         var mode = this.getFieldValue('MODE');
         var action = this.getFieldValue('ACTION');
@@ -5885,11 +5924,12 @@ Blockly.Blocks.wx_buffer = {
 
 Blockly.propc.wx_buffer = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx')) {
+    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx')) {
         var size = this.getFieldValue('SIZE') || '64';
         var code = '';
         var buffer = Blockly.propc.variableDB_.getName(this.getFieldValue('BUFFER'), Blockly.Variables.NAME_TYPE);
@@ -5956,11 +5996,12 @@ Blockly.Blocks.wx_disconnect = {
 
 Blockly.propc.wx_disconnect = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         Blockly.propc.definitions_["wx_def"] = '#include "wifi.h"';
         Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
     }
-    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx'))
+    if (allBlocks.indexOf('Simple WX initialize') === -1 && (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx'))
     {
         return 'wifi_disconnect(' + Blockly.propc.variableDB_.getName(this.getFieldValue('ID'), Blockly.Variables.NAME_TYPE) + ');\n';
     } else {
@@ -5983,7 +6024,8 @@ Blockly.Blocks.wx_ip = {
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-        if (allBlocks.toString().indexOf('WX initialize') === -1 && projectData['board'] !== 'heb-wx')
+        if (allBlocks.toString().indexOf('WX initialize') === -1 &&
+            window.project.boardType.name !== 'heb-wx')
         {
             this.setWarningText('WARNING: You must use a WX\ninitialize block at the beginning of your program!');
         }
@@ -5992,7 +6034,7 @@ Blockly.Blocks.wx_ip = {
 
 Blockly.propc.wx_ip = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (projectData['board'] === 'heb-wx') {
+    if (window.project.boardType.name === 'heb-wx') {
         if (allBlocks.indexOf('Simple WX initialize') > -1) {
             Blockly.propc.wx_init.call();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
         } else {
@@ -6000,7 +6042,8 @@ Blockly.propc.wx_ip = function () {
             Blockly.propc.setups_["wx_init"] = 'wifi_start(31, 30, 115200, WX_ALL_COM);';
         }
     }
-    if (allBlocks.indexOf('WX initialize') > -1 || projectData['board'] === 'heb-wx')
+    if (allBlocks.indexOf('WX initialize') > -1 ||
+        window.project.boardType.name === 'heb-wx')
     {
         var mode = this.getFieldValue('MODE');
         if (!this.disabled) {

--- a/src/blockly/generators/propc/gpio.js
+++ b/src/blockly/generators/propc/gpio.js
@@ -1618,7 +1618,7 @@ Blockly.Blocks.sound_play = {
         this.setSoundAction(action);
     },
     onchange: function (event) {
-        if (!(projectData.board && (projectData.board === "heb" || projectData.board === "heb-wx"))) {
+        if (!(window.project.boardType.name === "heb" || window.project.boardType.name === "heb-wx")) {
             if (event.type == Blockly.Events.BLOCK_CREATE || event.type == Blockly.Events.BLOCK_DELETE) {
                 var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
                 if (allBlocks.indexOf('sound initialize') === -1) {
@@ -1658,14 +1658,16 @@ Blockly.propc.sound_play = function () {
     var code = 'sound_' + action + '(audio0, ' + channel + ', ' + value + ');';
 
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
-    if (allBlocks.indexOf('sound initialize') === -1 && !(projectData.board &&
-            (projectData.board === "heb") || (projectData.board === "heb-wx"))) {
+    if (allBlocks.indexOf('sound initialize') === -1 &&
+        !(window.project && (window.project.boardType.name === "heb") ||
+        window.project.boardType.name === "heb-wx")) {
         code = '// WARNING: You must use a sound initialize block at the beginning of your program!\n';
     }
 
-    if (projectData['board'] && !this.disabled) {
+    if (window.project && !this.disabled) {
         const profile = window.projectProfile;
-        if (projectData['board'] === "heb" || projectData['board'] === "heb-wx") {
+        if (window.project.boardType.name === "heb" ||
+            window.project.boardType.name === "heb-wx") {
             Blockly.propc.setups_["sound_start"] = 'audio0 = sound_run(' + profile.earphone_jack_inverted + ');';
         }
         Blockly.propc.definitions_["include_soundplayer"] = '#include "sound.h"';
@@ -1732,7 +1734,7 @@ Blockly.propc.wav_play = function () {
         if (!initFound) {
             Blockly.propc.setups_["sd_card"] = 'sd_mount(' + profile.sd_card + ');';
         }
-        if (projectData["board"] === "heb-wx" && !wPinFound) {
+        if (window.project.boardType.name === "heb-wx" && !wPinFound) {
             Blockly.propc.setups_["wavplayer_pin"] = 'wav_set_pins(' + profile.earphone_jack + ');';
         }
     }
@@ -1937,7 +1939,8 @@ Blockly.Blocks.sd_open = {
         this.setNextStatement(true, null);
     },
     onchange: function () {
-        if (projectData["board"] !== "activity-board" && projectData["board"] !== "heb-wx") {
+        if (window.project.boardType.name !== "activity-board" &&
+            window.project.boardType.name !== "heb-wx") {
             var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
             if (allBlocks.indexOf('SD initialize') === -1) {
                 this.setWarningText('WARNING: You must use a SD initialize\nblock at the beginning of your program!');
@@ -1979,7 +1982,8 @@ Blockly.propc.sd_open = function () {
     }
 
     var code = head + 'fp = fopen("' + fp + '","' + mode + '");';
-    if (projectData["board"] !== "activity-board" && projectData["board"] !== "heb-wx" &&
+    if (window.project.boardType.name !== "activity-board" &&
+        window.project.boardType.name !== "heb-wx" &&
             allBlocks.toString().indexOf('SD initialize') === -1) {
         code = '// WARNING: You must use a SD initialize block at the beginning of your program!';
     }
@@ -2068,8 +2072,9 @@ Blockly.Blocks.sd_read = {
             var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
             if (allBlocks.indexOf('SD file open') === -1) {
                 warnTxt = 'WARNING: You must use a SD file open block\nbefore reading, writing, or closing an SD file!';
-            } else if (allBlocks.indexOf('SD initialize') === -1 && projectData["board"] !== "heb-wx"
-                    && projectData["board"] !== "activity-board") {
+            } else if (allBlocks.indexOf('SD initialize') === -1 &&
+                window.project.boardType.name !== "heb-wx" &&
+                window.project.boardType.name !== "activity-board") {
                 warnTxt = 'WARNING: You must use a SD initialize\nblock at the beginning of your program!';
             }
             this.setWarningText(warnTxt);
@@ -2107,8 +2112,9 @@ Blockly.propc.sd_read = function () {
     var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
     if (allBlocks.indexOf('SD file open') === -1) {
         code = '// WARNING: You must use a SD file open block before reading, writing, or closing an SD file!';
-    } else if (allBlocks.indexOf('SD initialize') === -1 && projectData["board"] !== "heb-wx"
-            && projectData["board"] !== "activity-board") {
+    } else if (allBlocks.indexOf('SD initialize') === -1 &&
+        window.project.boardType.name !== "heb-wx" &&
+        window.project.boardType.name !== "activity-board") {
         code = '// WARNING: You must use a SD initialize block at the beginning of your program!';
     }
 
@@ -2197,8 +2203,9 @@ Blockly.propc.sd_file_pointer = function () {
 
     if (allBlocks.indexOf('SD file open') === -1) {
         code = '// WARNING: You must use a SD file open block before using the file pointer!';
-    } else if (allBlocks.indexOf('SD initialize') === -1 && projectData["board"] !== "heb-wx"
-            && projectData["board"] !== "activity-board") {
+    } else if (allBlocks.indexOf('SD initialize') === -1 &&
+        window.project.boardType.name !== "heb-wx" &&
+        window.project.boardType.name !== "activity-board") {
         code = '// WARNING: You must use a SD initialize block at the beginning of your program!';
     } else if (this.getFieldValue('MODE') === 'set') {
         var fp = Blockly.propc.valueToCode(this, 'FP', Blockly.propc.ORDER_NONE) || '0';
@@ -2228,7 +2235,7 @@ Blockly.Blocks.ab_drive_init = {
                     ["ActivityBot", "abdrive.h"],
                     ["Arlo", "arlodrive.h"],
                     ["Servo Differential Drive", "servodiffdrive.h"]];
-        if (projectData["board"] !== "activity-board") {
+        if (window.project.boardType.name !== "activity-board") {
             botTypeMenu = [["Servo Differential Drive", "servodiffdrive.h"]];
         }
         this.setTooltip(Blockly.MSG_ROBOT_DRIVE_INIT_TOOLTIP);
@@ -2245,7 +2252,7 @@ Blockly.Blocks.ab_drive_init = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-        if (projectData["board"] !== "activity-board") {
+        if (window.project.boardType.name !== "activity-board") {
             this.updateShape_({"BOT": "servodiffdrive.h", "LEFT": '12', "RIGHT": '13'});
         }
     },
@@ -2342,7 +2349,7 @@ Blockly.Blocks.ab_drive_ramping = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
         this.isBot = '';
-        if (projectData["board"] !== "activity-board") {
+        if (window.project.boardType.name !== "activity-board") {
             this.newRobot('servodiffdrive.h');
         }
     },

--- a/src/blockly/generators/propc/heb.js
+++ b/src/blockly/generators/propc/heb.js
@@ -785,7 +785,7 @@ Blockly.Blocks.heb_touchpad_status = {
         this.setTooltip(Blockly.MSG_HEB_TOUCHPAD_STATUS_TOOLTIP);
         this.setHelpUrl(Blockly.MSG_BADGE_BUTTONS_HELPURL);
         this.setColour(colorPalette.getColor('input'));
-        if (projectData && projectData.board !== 'heb-wx') {
+        if (window.project.boardType.name !== 'heb-wx') {
             this.appendDummyInput()
                     .appendField("Touchpad")
                     .appendField(new Blockly.FieldDropdown([

--- a/src/blockly/generators/propc/sensors.js
+++ b/src/blockly/generators/propc/sensors.js
@@ -2441,7 +2441,7 @@ Blockly.Blocks.sirc_get = {
         this.setColour(colorPalette.getColor('input'));
         this.pinChoices = ['PIN'];
         this.otherPin = [false];
-        if (projectData.board && projectData.board === "heb-wx") {
+        if (window.project.boardType.name === "heb-wx") {
             this.appendDummyInput()
                 .appendField("Sony Remote value received");
         } else {
@@ -2460,7 +2460,7 @@ Blockly.Blocks.sirc_get = {
 
 Blockly.propc.sirc_get = function () {
     var pin = '0';
-    if (projectData.board && projectData.board === "heb-wx") {
+    if (window.project.boardType.name === "heb-wx") {
         pin = '23';
     } else if (this.otherPin[0]) {
         pin = Blockly.propc.valueToCode(this, 'PIN', Blockly.propc.ORDER_ATOMIC) || '0';

--- a/src/modules/code_editor.js
+++ b/src/modules/code_editor.js
@@ -23,21 +23,6 @@
 import {isExperimental} from './url_parameters';
 import {EMPTY_PROJECT_CODE_HEADER} from './constants';
 
-/**
- * TODO: Identify the purpose of this variable
- *
- * @type {{}}
- */
-let codePropC = null;
-
-
-/**
- * TODO: Identify the purpose of this variable
- *
- * @type {null}
- */
-let codeXml = null;
-
 
 /**
  * Prop c code editor implementing the Ace package
@@ -48,24 +33,26 @@ class CodeEditor {
    * @param {string} boardType
    */
   constructor(boardType) {
-    if (!codePropC) {
-      codePropC = ace.edit('code-propc');
-      codePropC.setTheme('ace/theme/chrome');
-      codePropC.getSession().setMode('ace/mode/c_cpp');
-      codePropC.getSession().setTabSize(2);
-      codePropC.$blockScrolling = Infinity;
-      codePropC.setReadOnly(true);
+    if (!window.codePropC) {
+      const code = ace.edit('code-propc');
+      code.setTheme('ace/theme/chrome');
+      code.getSession().setMode('ace/mode/c_cpp');
+      code.getSession().setTabSize(2);
+      code.$blockScrolling = Infinity;
+      code.setReadOnly(true);
 
       // if the project is a propc code-only project, enable code editing.
       if (boardType === 'propcfile') {
-        codePropC.setReadOnly(false);
+        code.setReadOnly(false);
       }
+      setPropCCode(code);
     }
 
-    if (!codeXml && isExperimental.indexOf('xedit') > -1) {
-      codeXml = ace.edit('code-xml');
-      codeXml.setTheme('ace/theme/chrome');
-      codeXml.getSession().setMode('ace/mode/xml');
+    if (!window.codeXml && isExperimental.indexOf('xedit') > -1) {
+      const xmlCode = ace.edit('code-xml');
+      xmlCode.setTheme('ace/theme/chrome');
+      xmlCode.getSession().setMode('ace/mode/xml');
+      setPropCodeXml(xmlCode);
     }
   }
 
@@ -73,7 +60,7 @@ class CodeEditor {
    * Ace editor Undo command
    */
   undo() {
-    codePropC.undo();
+    window.codePropC.undo();
   }
 
 
@@ -81,7 +68,7 @@ class CodeEditor {
    * Ace editor Redo command
    */
   redo() {
-    codePropC.redo();
+    window.codePropC.redo();
   }
 }
 
@@ -93,6 +80,7 @@ class CodeEditor {
  */
 function propcAsBlocksXml() {
   let code = EMPTY_PROJECT_CODE_HEADER;
+  const codePropC = window.codePropC;
   code += '<block type="propc_file" id="' +
       generateBlockId(codePropC ?
           codePropC.getValue() : 'thequickbrownfoxjumpedoverthelazydog') +
@@ -129,5 +117,22 @@ function generateBlockId(nonce) {
   return blockId;
 }
 
+
+/**
+ * Set the global codePropC variable
+ * @param {Object} value
+ */
+function setPropCCode(value) {
+  window.codePropC = value;
+}
+
+
+/**
+ *
+ * @param {object} value
+ */
+function setPropCodeXml(value) {
+  window.codeXml = value;
+}
 
 export {CodeEditor, propcAsBlocksXml};

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -30,9 +30,10 @@ let projectInitialState = null;
 
 /**
  * Current project profile
- * @type {Project.boardType |null}
+ * @type {Project.boardType | null}
  */
 let defaultProfile = null;
+
 
 /**
  * Reset the initial project state to null
@@ -58,6 +59,10 @@ function setProjectInitialState(project) {
   if (project instanceof Project) {
     if (project !== projectInitialState) {
       projectInitialState = project;
+
+      // Add the the project to the ES5 global space for the
+      // custom block definitions
+      window.project = project;
     }
     return projectInitialState;
   }
@@ -80,6 +85,9 @@ function getDefaultProfile() {
  */
 function setDefaultProfile(value) {
   defaultProfile = value;
+
+  // Add the the project profile (aka board type) to the ES5 global
+  // space for the custom block definitions
   window.projectProfile = value;
 }
 
@@ -404,20 +412,134 @@ Project.prototype.EmptyProjectCodeHeader = '<xml xmlns="http://www.w3.org/1999/x
  * implementation in case we want to introduce another language, such
  * as Python or GoLang.
  *
- * @type {{UNKNOWN: string, PROPC: string}}
+ * @type {{
+ *  UNKNOWN: string,
+ *  PROPC: string
+ *  }}
  */
 const ProjectTypes = {
   'PROPC': 'PROPC',
   'UNKNOWN': 'UNKNOWN',
 };
 
-
-// noinspection DuplicatedCode
 /**
  * Board types describe the various types of hardware the project
  * will support. This includes robots, project boards and the S3
  *
- * @type Object - This returns a board type object
+ * // This returns a board type object
+ * @type {{
+ *  propcfile: {
+ *    digital: string[][],
+ *    saves_to: [],
+ *    analog: [],
+ *    baudrate: number,
+ *    name: string,
+ *    description: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *    },
+ *  s3: {
+ *    digital: string[][],
+ *    saves_to: [
+ *      [string, string]
+ *    ],
+ *    analog: [
+ *      [string, string],
+ *      [string, string]
+ *    ],
+ *    baudrate: number,
+ *    name: string,
+ *    description: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *    },
+ *  activityboard: {
+ *    digital: string[][],
+ *    saves_to: [
+ *      [string, string],
+ *      [string, string],
+ *      [string, string]
+ *      ],
+ *    analog: [
+ *      [string, string],
+ *      [string, string],
+ *      [string, string],
+ *      [string, string]
+ *      ],
+ *    earphone_jack_inverted: string,
+ *    baudrate: number,
+ *    sd_card: string,
+ *    name: string,
+ *    description: string,
+ *    earphone_jack: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *    },
+ *  other: {
+ *    digital: string[][],
+ *    saves_to: [
+ *      [string, string],
+ *      [string, string],
+ *      [string, string]
+ *      ],
+ *    analog: [],
+ *    baudrate: number,
+ *    name: string,
+ *    description: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *    },
+ *  heb: {
+ *    digital: string[][],
+ *    saves_to: [
+ *      [string, string],
+ *      [string, string]
+ *    ],
+ *    analog: [],
+ *    earphone_jack_inverted: string,
+ *    baudrate: number,
+ *    name: string,
+ *    description: string,
+ *    earphone_jack: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *    },
+ *  flip: {
+ *    digital: string[][],
+ *    saves_to: [
+ *      [string, string],
+ *      [string, string],
+ *      [string, string]
+ *      ],
+ *    analog: [],
+ *    baudrate: number,
+ *    name: string,
+ *    description: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *    },
+ *  hebwx: {
+ *    digital: string[][],
+ *    saves_to: [
+ *      [string, string],
+ *      [string, string]
+ *      ],
+ *    analog: [],
+ *    earphone_jack_inverted: string,
+ *    baudrate: number,
+ *    sd_card: string,
+ *    name: string,
+ *    description: string,
+ *    earphone_jack: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *    },
+ *  unknown: {
+ *    saves_to: [],
+ *    name: string,
+ *    description: string
+ *    }
+ *  }}
  */
 const ProjectProfiles = {
   'activityboard': {

--- a/src/modules/project_profile.js
+++ b/src/modules/project_profile.js
@@ -25,6 +25,7 @@ let activeProfile = null;
 /**
  * This is a singleton class that holds the representation of the original
  * state of the project that is currently loaded onto the editor canvas.
+ * @class
  */
 export default class ProjectProfile {
   /**
@@ -40,6 +41,66 @@ export default class ProjectProfile {
 
     this.state = 'duke';
     this.instance = this;
+    this.digital = [[]];
+
+    /*
+     *  activityboard: {
+    *    digital: string[][],
+    *    saves_to: [
+      *      [string, string],
+    *      [string, string],
+    *      [string, string]
+      *      ],
+    *    analog: [
+      *      [string, string],
+    *      [string, string],
+    *      [string, string],
+    *      [string, string]
+      *      ],
+    *    earphone_jack_inverted: string,
+    *    baudrate: number,
+    *    sd_card: string,
+    *    name: string,
+    *    description: string,
+    *    earphone_jack: string,
+    *    contiguous_pins_end: number,
+    *    contiguous_pins_start: number
+      *    },
+      */
   }
 }
 
+
+/**
+ * @type {{
+ *  digital: string[][],
+ *  saves_to: [
+ *    [string, string],
+ *    [string, string],
+ *    [string, string]
+ *    ],
+ *  analog: [
+ *    [string, string],
+ *    [string, string],
+ *    [string, string],
+ *    [string, string]
+ *    ],
+ *    earphone_jack_inverted: string,
+ *    baudrate: number,
+ *    sd_card: string,
+ *    name: string,
+ *    description: string,
+ *    earphone_jack: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+}}
+ */
+const testBoardType = {
+  name: '',
+  description: '',
+  earphone_jack: '',
+  earphone_jack_inverted: '',
+  baudrate: 9600,
+};
+
+console.log('BoardType is: %s', testBoardType);


### PR DESCRIPTION
Refactor code to remove projectData references.
Refactor code to remove global codePropC references.
Update src/README to include more updated blocks.

The UI is again able to view the C source code generated from the project blocks. 