### PR TITLE
Patch fm 200413a

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,14 +53,10 @@
         <link type="image/png" rel="icon" sizes="16x16" href="src/images/favicon-16x16.png"/>
 
         <title>BlocklyProp Solo</title>
-        <script type="application/javascript" src="src/lib/jquery-1.11.3.min.js" defer></script>
-        <script type="application/javascript" src="src/lib/bootstrap/core/js/bootstrap.min.js" defer></script>
         <script src="https://browser.sentry-cdn.com/5.12.1/bundle.min.js"
                 integrity="sha384-y+an4eARFKvjzOivf/Z7JtMJhaN6b+lLQ5oFbBbUwZNNVir39cYtkjW1r6Xjbxg3"
                 crossorigin="anonymous" defer>
         </script>
-        <script type="application/javascript" src="src/globals.js" defer></script>
-        <script type="application/javascript" src="src/utils.js" defer></script>
         <script type="module" src="dist/index.bundle.js" defer></script>
     </head>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,8 +383,7 @@
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-      "dev": true
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -1198,6 +1197,623 @@
         "upath": "^1.1.1"
       },
       "dependencies": {
+        "fsevents": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+          "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
+            "node-pre-gyp": "*"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "resolved": false,
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "resolved": false,
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "resolved": false,
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": false,
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.4",
+              "resolved": false,
+              "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "resolved": false,
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "resolved": false,
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "resolved": false,
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": false,
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "3.2.6",
+              "resolved": false,
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "resolved": false,
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "resolved": false,
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "resolved": false,
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "resolved": false,
+              "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": false,
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "resolved": false,
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.6",
+              "resolved": false,
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "resolved": false,
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.3",
+              "resolved": false,
+              "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": false,
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": false,
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "resolved": false,
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": false,
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": false,
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": false,
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.3.3",
+              "resolved": false,
+              "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.9.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.3",
+              "resolved": false,
+              "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": false,
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.3",
+              "resolved": false,
+              "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.14.0",
+              "resolved": false,
+              "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4.4.2"
+              }
+            },
+            "nopt": {
+              "version": "4.0.3",
+              "resolved": false,
+              "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.1.1",
+              "resolved": false,
+              "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "resolved": false,
+              "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.8",
+              "resolved": false,
+              "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "resolved": false,
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "resolved": false,
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "resolved": false,
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": false,
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": false,
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "resolved": false,
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "resolved": false,
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": false,
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "resolved": false,
+              "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "resolved": false,
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": false,
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": false,
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": false,
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "resolved": false,
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "resolved": false,
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": false,
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": false,
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "resolved": false,
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "resolved": false,
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.13",
+              "resolved": false,
+              "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": false,
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "resolved": false,
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": false,
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -2319,14 +2935,6 @@
         "acorn": "^7.1.0",
         "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -2670,11 +3278,6 @@
         "object-keys": "^1.0.6"
       },
       "dependencies": {
-        "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
-        },
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -2960,562 +3563,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1",
-        "node-pre-gyp": "*"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.6.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.3.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.9.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.14.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4.4.2"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "npm-normalize-package-bin": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.13",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4447,14 +4498,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "jsprim": {
@@ -4792,8 +4835,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -5984,13 +6026,6 @@
         "buffer-equal": "0.0.1",
         "minimist": "^1.1.3",
         "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
       }
     },
     "ramda": {
@@ -6100,81 +6135,17 @@
         "es-abstract": "^1.17.0-next.1"
       },
       "dependencies": {
-        "es-abstract": {
-          "version": "1.17.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
           "requires": {
             "has": "^1.0.3"
-          }
-        },
-        "object-inspect": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "dev": true
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
           }
         }
       }
@@ -7831,15 +7802,6 @@
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "css-loader": "^3.4.2",
     "eslint": "^6.6.0",
     "eslint-config-google": "^0.14.0",
+    "fsevents": "^2.1.2",
     "minimist": "^1.2.5",
     "mocha": "^6.2.3",
     "sinon": "^7.5.0",

--- a/src/modules/blockly/generators/propc.js
+++ b/src/modules/blockly/generators/propc.js
@@ -647,9 +647,16 @@ Blockly.propc.finish = function(code) {
       for (const method in Blockly.propc.cog_methods_) {
         if (Blockly.propc.methods_[method]
             .indexOf(definitions[def]
-                .replace(/[charint]* (\w+)[\[\]0-9]*;/g, '$1')) > -1) {
+                .replace(/[charint]* (\w+)[[\]0-9]*;/g, '$1')) > -1) {
           functionVariables.push(definitions[def]);
         }
+
+        // TODO: Remove this code when the regEx above has been verified.
+        // if (Blockly.propc.methods_[method]
+        //     .indexOf(definitions[def]
+        //         .replace(/[charint]* (\w+)[\[\]0-9]*;/g, '$1')) > -1) {
+        //   functionVariables.push(definitions[def]);
+        // }
       }
     }
   }

--- a/src/modules/blockly/generators/propc/variables.js
+++ b/src/modules/blockly/generators/propc/variables.js
@@ -116,7 +116,7 @@ Blockly.propc.variables_set = function() {
     } else if (argument0.indexOf('char') > -1) {
       Blockly.propc.vartype_[varName] = 'char';
       Blockly.propc.varlength_[varName] = '{{$var_length_' + varName + '}};';
-    } else if (argument0.indexOf('char\[\]') > -1) {
+    } else if (argument0.indexOf('char[]') > -1) {
       Blockly.propc.vartype_[varName] = 'char *';
     } else if (argument0.indexOf('"') > -1 && argument0.indexOf('"') < 4) {
       // Some functions that return numbers take strings as arguments, so
@@ -139,7 +139,7 @@ Blockly.propc.variables_set = function() {
   } else if (argument0.indexOf('char') > -1) {
     Blockly.propc.vartype_[varName] = 'char';
     Blockly.propc.varlength_[varName] = '{{$var_length_' + varName + '}};';
-  } else if (argument0.indexOf('char\[\]') > -1) {
+  } else if (argument0.indexOf('char[]') > -1) {
     Blockly.propc.vartype_[varName] = 'char *';
   }
 
@@ -545,9 +545,9 @@ Blockly.propc.array_fill = function() {
       this.getFieldValue('VAR'), 'Array');
   let varVals = this.getFieldValue('NUM');
   if (varVals.indexOf('0x') === 0 || varVals.indexOf(',0x') > 0) {
-    varVals = varVals.replace(/[^0-9xA-Fa-f,-\.]/g, '');
+    varVals = varVals.replace(/[^0-9xA-Fa-f,-.]/g, '');
   } else {
-    varVals = varVals.replace(/[^0-9b,-\.]/g, '');
+    varVals = varVals.replace(/[^0-9b,-.]/g, '');
   }
   varVals = varVals.replace(/,\./g, ',0.')
       .replace(/\b\.[0-9-]+,\b/g, ',')

--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -35,7 +35,7 @@ import {getPropTerminal} from './prop_term';
 import {getProjectInitialState} from './project';
 import {isExperimental} from './url_parameters';
 import {getSourceEditor} from './code_editor';
-import {logConsoleMessage} from './utility';
+import {logConsoleMessage, utils} from './utility';
 
 
 /**
@@ -399,7 +399,8 @@ function cloudCompile(text, action, successHandler) {
   }
 
   if (propcCode.indexOf('EMPTY_PROJECT') > -1) {
-    utils.showMessage(Blockly.Msg.DIALOG_EMPTY_PROJECT, Blockly.Msg.DIALOG_CANNOT_COMPILE_EMPTY_PROJECT);
+    utils.showMessage(Blockly.Msg.DIALOG_EMPTY_PROJECT,
+        Blockly.Msg.DIALOG_CANNOT_COMPILE_EMPTY_PROJECT);
   } else {
     $('#compile-dialog-title').text(text);
     $('#compile-console').val('Compile... ');

--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -1813,7 +1813,6 @@ function establishBPLauncherConnection() {
         // ports: ['port1', 'port2', 'port3'...]
         setPortListUI(wsMessage.ports);
         clientService.portListReceiveCountUp = 0;
-        logConsoleMessage('Received new port list: '+ wsMessage.ports.toString());
 
         // --- serial terminal/graph
       } else if (wsMessage.type === 'serial-terminal' &&

--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -337,9 +337,9 @@ const formatWizard = function() {
 const prettyCode = function(rawCode) {
   // Prevent JS beautify from improperly formatting reference, dereference, and arrow operators
   rawCode = rawCode
-      .replace(/\*([_a-zA-Z\()])/g, '___REFERENCE_OPERATOR___$1')
-      .replace(/([_a-zA-Z\()])\*/g, '$1___REFERENCE_OPERATOR___')
-      .replace(/&([_a-zA-Z\()])/g, '___DEREFERENCE_OPERATOR___$1')
+      .replace(/\*([_a-zA-Z()])/g, '___REFERENCE_OPERATOR___$1')
+      .replace(/([_a-zA-Z()])\*/g, '$1___REFERENCE_OPERATOR___')
+      .replace(/&([_a-zA-Z()])/g, '___DEREFERENCE_OPERATOR___$1')
       .replace(/->/g, '___ARROW_OPERATOR___');
 
   // run the beautifier
@@ -574,9 +574,9 @@ export function loadInto(modalMessage, compileCommand, loadOption, loadAction) {
             document.getElementById('compile-console').scrollTop =
                 document.getElementById('compile-console').scrollHeight;
             if (terminalNeeded === 'term' && loadData.success) {
-              serial_console();
+              serialConsole();
             } else if (terminalNeeded === 'graph' && loadData.success) {
-              graphing_console();
+              graphingConsole();
             }
           });
         } else {
@@ -594,9 +594,9 @@ export function loadInto(modalMessage, compileCommand, loadOption, loadAction) {
             document.getElementById('compile-console').scrollTop =
                 document.getElementById('compile-console').scrollHeight;
             if (terminalNeeded === 'term' && loadData.success) {
-              serial_console();
+              serialConsole();
             } else if (terminalNeeded === 'graph' && loadData.success) {
-              graphing_console();
+              graphingConsole();
             }
           });
         }
@@ -614,7 +614,7 @@ export function loadInto(modalMessage, compileCommand, loadOption, loadAction) {
  * Serial console support
  */
 // eslint-disable-next-line camelcase,require-jsdoc
-function serial_console() {
+function serialConsole() {
   clientService.sendCharacterStreamTo = 'term';
 
   // HTTP client
@@ -740,7 +740,7 @@ function displayTerminalConnectionStatus(connectionInfo) {
  * Graphing console
  */
 // eslint-disable-next-line camelcase,require-jsdoc
-function graphing_console() {
+function graphingConsole() {
   clientService.sendCharacterStreamTo = 'graph';
 
   if (getGraphSettingsFromBlocks()) {
@@ -1080,12 +1080,12 @@ function sanitizeFilename(input) {
   }
 
   // replace OS-illegal characters or phrases
-  input = input.replace(/[\/\?<>\\:\*\|"]/g, '_')
+  input = input.replace(/[/?<>\\:*|"]/g, '_')
       // eslint-disable-next-line no-control-regex
       .replace(/[\x00-\x1f\x80-\x9f]/g, '_')
       .replace(/^\.+$/, '_')
       .replace(/^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i, '_')
-      .replace(/[\. ]+$/, '_');
+      .replace(/[. ]+$/, '_');
 
   // if the filename is too long, truncate it
   if (input.length > 31) {
@@ -1859,9 +1859,9 @@ function establishBPLauncherConnection() {
         // msg: [String message]
 
         if (wsMessage.action === 'open-terminal') {
-          serial_console();
+          serialConsole();
         } else if (wsMessage.action === 'open-graph') {
-          graphing_console();
+          graphingConsole();
         } else if (wsMessage.action === 'close-terminal') {
           $('#console-dialog').modal('hide');
           clientService.sendCharacterStreamTo = null;
@@ -2023,6 +2023,7 @@ function addComPortDeviceOption(port) {
 
 export {
   compile,  init, renderContent, downloadCSV, initializeBlockly,
-  sanitizeFilename, findClient, formatWizard,
+  sanitizeFilename, findClient, formatWizard, serialConsole,
+  graphingConsole, configureConnectionPaths,
 };
 

--- a/src/modules/code_editor.js
+++ b/src/modules/code_editor.js
@@ -98,6 +98,26 @@ class CodeEditor {
   redo() {
     cSourceCode.redo();
   }
+
+  /**
+   * Search for a matching element
+   * @param {string} needle
+   * @param {Object} options
+   * @param {boolean} isAnimated
+   */
+  find(needle, options, isAnimated) {
+    cSourceCode.find(needle, options, isAnimated);
+  }
+
+  /**
+   * Replace the selected text with the replacement text
+   * @param {string} source
+   * @param {string} replacement
+   * @param {Object} options
+   */
+  replace(source, replacement, options) {
+    cSourceCode.replace(replacement, options);
+  }
 }
 
 

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -44,8 +44,9 @@ import {
 import {
   clientService, compile, findClient, formatWizard, getComPort, loadInto,
   renderContent, downloadCSV, initializeBlockly, sanitizeFilename,
+  graphingConsole, serialConsole, configureConnectionPaths,
 } from './blocklyc';
-import {CodeEditor, propcAsBlocksXml} from './code_editor.js';
+import {CodeEditor, propcAsBlocksXml, getSourceEditor} from './code_editor.js';
 import {
   editProjectDetails, newProjectModal, openProjectModal, initUploadModalLabels,
 } from './modals';
@@ -451,24 +452,27 @@ function initEventHandlers() {
     loadInto('Load into EEPROM', 'eeprom', 'CODE', 'EEPROM');
   });
 
-  $('#prop-btn-term').on('click', () => serial_console());
-  $('#prop-btn-graph').on('click', () => graphing_console());
+  $('#prop-btn-term').on('click', () => serialConsole());
+  $('#prop-btn-graph').on('click', () => graphingConsole());
   // Deprecated.
   //  $('#prop-btn-find-replace').on('click', () => findReplaceCode());
   $('#prop-btn-pretty').on('click', () => formatWizard());
 
-  $('#prop-btn-undo').on('click', () => codePropC.undo());
-  $('#prop-btn-redo').on('click', () => codePropC.redo());
+  $('#prop-btn-undo').on('click', () => getSourceEditor().undo());
+  $('#prop-btn-redo').on('click', () => getSourceEditor().redo());
 
   // TODO: The event handler is just stub code.
   $('#term-graph-setup').on('click', () => configureTermGraph());
 
   $('#propc-find-btn').on('click', () => {
-    codePropC.find(document.getElementById('propc-find').value, {}, true);
+    getSourceEditor().find(
+        document.getElementById('propc-find').value,
+        {},
+        true);
   });
 
   $('#propc-replace-btn').on('click', () => {
-    codePropC.replace(
+    getSourceEditor().replace(
         document.getElementById('propc-replace').value,
         {needle: document.getElementById('propc-find').value},
         true);
@@ -707,7 +711,7 @@ function initCdnImageUrls() {
 
 
 /**
- * Populate the projectData global
+ * Populate the Blockly workspace with the new project
  *
  * @param {Project} data is the current project object
  * @param {function} callback is called if provided when the function completes
@@ -1607,6 +1611,7 @@ function clearUploadInfo(redirect) {
  * For offline mode, the project may not have been loaded yet.
  */
 // eslint-disable-next-line no-unused-vars,require-jsdoc
+/*
 function uploadMergeCode(append) {
   // Hide the Open Project modal dialog
   $('#upload-dialog').modal('hide');
@@ -1737,7 +1742,7 @@ function uploadMergeCode(append) {
     clearUploadInfo(false);
   }
 }
-
+*/
 
 /**
  * Replace the default Blockly fonts

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -20,12 +20,13 @@
  *   DEALINGS IN THE SOFTWARE.
  */
 
+import 'bootstrap';
 import {
   APP_VERSION,
   ApplicationName,
   productBannerHostTrigger,
-  TestApplicationName} from './constants.js';
-
+  TestApplicationName} from './constants';
+import {getURLParameter} from './utility';
 
 /**
  * Display the BlocklyProp Solo license in a modal window
@@ -33,7 +34,6 @@ import {
 function showLicense() {
   $('#licenseModal').modal();
 }
-
 
 /**
  * Display the application name
@@ -45,7 +45,6 @@ function showAppName() {
   }
   $('#nav-logo').html(html);
 }
-
 
 /**
  * Display the app name in the banner
@@ -59,7 +58,6 @@ function showAppBannerTitle(appName) {
   }
 }
 
-
 /**
  * Set the ending copyright date
  * @param {HTMLElement} element
@@ -69,7 +67,6 @@ function setCopyrightDate(element) {
   element.innerHTML = 'v' + APP_VERSION + ' &copy; 2015 - ' +
       d.getFullYear().toString() + ', Parallax Inc.';
 }
-
 
 let appName = ApplicationName;
 if (window.location.hostname === productBannerHostTrigger) {
@@ -81,12 +78,11 @@ showAppBannerTitle(appName);
 setCopyrightDate(document.getElementById('footer_copyright'));
 setCopyrightDate(document.getElementById('license-copyright-date'));
 
-
 // The browser localStorage object should be empty
 window.localStorage.clear();
 
 // Add experimental URL parameter to the open and new project links, if used
-if (window.getURLParameter('experimental')) {
+if (getURLParameter('experimental')) {
   $('.editor-link').attr('href', function() {
     return document.location.href +
         window.getAllURLParameters().replace('?', '&');

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -30,7 +30,50 @@ let projectInitialState = null;
 
 /**
  * Current project profile
- * @type {Project.boardType | null}
+ * @type {
+ *  {
+ *    digital: string[][],
+ *    saves_to: ((string)[])[],
+ *    analog: ((string)[])[],
+ *    earphone_jack_inverted: string,
+ *    baudrate: number,
+ *    sd_card: string,
+ *    name: string,
+ *    description: string,
+ *    earphone_jack: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *  } |
+ *  {
+ *    digital: string[][],
+ *    saves_to: ((string)[])[],
+ *    analog: *[],
+ *    earphone_jack_inverted: string,
+ *    baudrate: number,
+ *    sd_card: string,
+ *    name: string,
+ *    description: string,
+ *    earphone_jack: string,
+ *    contiguous_pins_end: number,
+ *    contiguous_pins_start: number
+ *  } |
+ *  ProjectProfiles |
+ *  {
+ *    saves_to: *[],
+ *    name: string,
+ *    description: string
+ *  } |
+ *  {
+ *    saves_to: [],
+ *    name: string,
+ *    description: string
+ *  } |
+ *  {
+ *    saves_to: [],
+ *    name: string,
+ *    description: string
+ *  }
+ * }
  */
 let defaultProfile = null;
 
@@ -54,16 +97,13 @@ function getProjectInitialState() {
 /**
  * Set the project state from an existing project object
  * @param {Project} project
- * @return {Project}
+ * @return {Project | null}
  */
 function setProjectInitialState(project) {
   if (project instanceof Project) {
     if (project !== projectInitialState) {
       projectInitialState = project;
-
-      // Add the the project to the ES5 global space for the
-      // custom block definitions
-      window.project = project;
+      defaultProfile = project.boardType;
     }
     return projectInitialState;
   }
@@ -72,9 +112,43 @@ function setProjectInitialState(project) {
   return null;
 }
 
+// eslint-disable-next-line valid-jsdoc
 /**
  * Return the current project profile
- * @return {Project.boardType}
+ *
+ * @return {
+ *    {
+ *      digital: string[][],
+ *      saves_to: string[][],
+ *      analog: string[][],
+ *      earphone_jack_inverted: string,
+ *      baudrate: number,
+ *      sd_card: string,
+ *      name: string,
+ *      description: string,
+ *      earphone_jack: string,
+ *      contiguous_pins_end: number,
+ *      contiguous_pins_start: number
+ *    } |
+ *    {
+ *      digital: string[][],
+ *      saves_to: string[][],
+ *      analog: *[],
+ *      earphone_jack_inverted: string,
+ *      baudrate: number,
+ *      sd_card: string,
+ *      name: string,
+ *      description: string,
+ *      earphone_jack: string,
+ *      contiguous_pins_end: number,
+ *      contiguous_pins_start: number
+ *    } |
+ *    ProjectProfiles |
+ *    {
+ *      saves_to: *[],
+ *      name: string,
+ *      description: string
+ *  }}
  */
 function getDefaultProfile() {
   return defaultProfile;
@@ -86,10 +160,6 @@ function getDefaultProfile() {
  */
 function setDefaultProfile(value) {
   defaultProfile = value;
-
-  // Add the the project profile (aka board type) to the ES5 global
-  // space for the custom block definitions
-  window.projectProfile = value;
 }
 
 
@@ -721,10 +791,33 @@ const ProjectProfiles = {
   'unknown': {
     name: 'unknown',
     description: 'Board type is unknown',
+    digital: [['P0', '0']],
+    analog: [['A0', '0']],
     saves_to: [],
   },
 };
 
+
+/**
+ * A board type interface definition
+ *
+ * @typedef {{
+ *    boardType:object,
+ *    board:string,
+ *    board.name:string,
+ *    board.description:string,
+ *    board.digital:string [][],
+ *    board.analog:string [][],
+ *    [board.earphone_jack]:string,
+ *    [board.earphone_jack_inverted]:string,
+ *    [board.baudrate]:number,
+ *    [board.sd_card]:string,
+ *    [board.contiguous_pins_start]:number,
+ *    [board.contiguous_pins_end],
+ *     board.saves_to:string [][]
+ *    }}
+ */
+Project.aBoardType;
 
 export {
   Project,

--- a/src/modules/toolbar_controller.js
+++ b/src/modules/toolbar_controller.js
@@ -64,21 +64,14 @@ function propToolbarButtonController() {
  */
 function clientConnectionUpdateUI(state) {
   if (state) {
-    // Hide the client available message to display the short form
+    // Hide the 'client unavailable' message and show the
+    // port selection message
     $('#client-available').removeClass('hidden');
-    // $('#client-available-short').removeClass('hidden');
-
-    // Hide the 'client unavailable' message
     $('#client-unavailable').addClass('hidden');
-    logConsoleMessage('Connected to client, Updating UI');
   } else {
-    // Toggle the client available message to display the short form
+    // Client has not been detected. Show the 'client unavailable' message
     $('#client-available').addClass('hidden');
-    // $('#client-available-short').addClass('hidden');
-
-    // Show the 'client unavailable' message
     $('#client-unavailable').removeClass('hidden');
-    logConsoleMessage('Connected to client, Updating UI');
   }
 }
 

--- a/src/modules/toolbar_controller.js
+++ b/src/modules/toolbar_controller.js
@@ -21,7 +21,6 @@
  */
 
 import {getProjectInitialState} from './project.js';
-import {logConsoleMessage} from './utility';
 import {clientService} from './blocklyc';
 
 /**

--- a/src/modules/toolbar_controller.js
+++ b/src/modules/toolbar_controller.js
@@ -32,14 +32,16 @@ function propToolbarButtonController() {
 
   // No buttons are valid if there is no project.
   if (!project) {
-    disableButtons();
+    disableButtons(false);
     return;
   }
+
+  // The compile button should always be available when a project is loaded
+  setCompileButtonState(true, true);
 
   // Update elements when we are connected
   if (clientService.activeConnection) {
     clientConnectionUpdateUI(true);
-    setCompileButtonState(true, true);
 
     if (clientService.portsAvailable) {
       if (project.boardType.name === 's3') {
@@ -52,7 +54,7 @@ function propToolbarButtonController() {
     }
   } else {
     clientConnectionUpdateUI(false);
-    disableButtons();
+    disableButtons(true);
   }
 }
 
@@ -82,9 +84,12 @@ function clientConnectionUpdateUI(state) {
 
 /**
  * Disable the toolbar buttons
+ * @param {boolean} isProject is true if a project is loaded
  */
-function disableButtons() {
-  setCompileButtonState(true, false);
+function disableButtons(isProject) {
+  if (!isProject) {
+    setCompileButtonState(true, false);
+  }
   setLoadRAMButtonState(true, false);
   setLoadEEPROMButtonState(true, false);
   setTerminalButtonState(true, false);
@@ -95,7 +100,6 @@ function disableButtons() {
  * Disable the UI buttons for a non-S3 project
  */
 function disableUIButtonGroup() {
-  setCompileButtonState(true, true);
   setLoadRAMButtonState(true, false);
   setLoadEEPROMButtonState(true, false);
   setTerminalButtonState(true, false);
@@ -106,7 +110,6 @@ function disableUIButtonGroup() {
  * Set the UI buttons for an S3 project
  */
 function setS3UIButtonGroup() {
-  setCompileButtonState(true, true);
   setLoadRAMButtonState(false, false);
   setLoadEEPROMButtonState(true, true);
   setTerminalButtonState(true, true);
@@ -117,7 +120,7 @@ function setS3UIButtonGroup() {
  * Set the UI buttons for a non-S3 project
  */
 function setUIButtonGroup() {
-  setCompileButtonState(true, true);
+  // setCompileButtonState(true, true);
   setLoadRAMButtonState(true, true);
   setLoadEEPROMButtonState(true, true);
   setTerminalButtonState(true, true);

--- a/src/modules/utility.js
+++ b/src/modules/utility.js
@@ -365,4 +365,6 @@ function logConsoleMessage(message) {
 }
 
 
-export {utils, isExperimental, getAllUrlParameters, logConsoleMessage};
+export {
+  utils, isExperimental, getURLParameter, getAllUrlParameters,
+  logConsoleMessage};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,9 +49,15 @@ module.exports = {
         path: path.resolve(__dirname, 'dist'),
         // filename: '[name].[chunkhash].bundle.js',
         filename: '[name].bundle.js',
+        chunkFilename: '[name].bundle.js',
         pathinfo: true,
         sourceMapFilename: '[name].bundle.js.map',
     },
+    // optimization: {
+    //     splitChunks: {
+    //         chunks: 'all',
+    //     },
+    // },
     module: {
         rules: [
             {


### PR DESCRIPTION
* Correct import of the utils object. The bits from the original ./src/util.js file were moved to ./src/modules/utility.js.
* Remove script tags that loaded jquery and bootstrap in the index.HTML file. The jQuery package is now loaded as a global import in the webpack configuration file. Bootstrap is now loaded through an import statement as needed in each module.
* Remove debugging log messages.
* Add chunking support to webpack config.
* Clean up unneeded regEx escape characters.
* Refactor calls to cCodeEditor find and replace methods with methods exposed in the CodeEditor object.
* Update fsevents package to remove CVE. This is a dev package and only relevant to development under MacOS.