### PR TITLE
Add block to copy CSS assets to /dist.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,13 @@ module.exports = {
                 to: path.resolve(__dirname, 'dist/images')
             }
         ]),
+        // Copy over style sheets
+        new CopyPlugin([
+            { from: './src/site.css', to: path.resolve(__dirname, 'dist')},
+            { from: './src/style.css', to: path.resolve(__dirname, 'dist')},
+            { from: './src/style-clientdownload.css', to: path.resolve(__dirname, 'dist')},
+            { from: './src/style-editor.css', to: path.resolve(__dirname, 'dist')}
+        ]),
         new webpack.ProvidePlugin({
             $: 'jquery',
             jQuery: 'jquery'


### PR DESCRIPTION
Docker images were not receiving the .css files from the source repository. Update the webpack config to copy these assets to the /dist folder as part of the webpack build process.