### PR TITLE
Patch 200427b

### DIFF
--- a/src/modules/blockly/generators/propc/gpio.js
+++ b/src/modules/blockly/generators/propc/gpio.js
@@ -3470,7 +3470,7 @@ Blockly.propc.activitybot_parallaxy_load = function() {
 };
 
 /**
- * MCP 320x Read
+ * A/D Read block for Flip and Other board types
  * @type {{
  *  init: Blockly.Blocks.mcp320x_read.init,
  *  updateShape_: Blockly.Blocks.mcp320x_read.updateShape_,

--- a/src/modules/modals.js
+++ b/src/modules/modals.js
@@ -569,7 +569,7 @@ function populateProjectBoardTypesUIElement(element, selected = null) {
               // Exclude the 'unknown' board type. It is used only when
               // something has gone wrong during a project load operation
               element.append($('<option />')
-                  .val(board)
+                  .val(ProjectProfiles[board].name)
                   .text(ProjectProfiles[board].description));
             }
           }

--- a/src/modules/toolbox_data.js
+++ b/src/modules/toolbox_data.js
@@ -1178,9 +1178,6 @@ xmlToolbox += '        <category key="category_sensor-input_LIS3DH" >';
 xmlToolbox += '            <block type="lis3dh_init"></block>';
 xmlToolbox += '            <block type="lis3dh_read"></block>';
 xmlToolbox += '            <block type="lis3dh_temp"></block>';
-
-// xmlToolbox += '            <block type="lis3dh_tilt"></block>';
-
 xmlToolbox += '        </category>';
 xmlToolbox += '        <category key="category_sensor-input_LSM9DS1" >';
 xmlToolbox += '            <block type="lsm9ds1_init"></block>';
@@ -1230,6 +1227,10 @@ xmlToolbox += '            <block type="dht22_read"></block>';
 xmlToolbox += '            <block type="dht22_value"></block>';
 xmlToolbox += '        </category>';
 xmlToolbox += '    </category>';
+
+/*
+ * MEMORY blocks
+ */
 xmlToolbox += '    <category key="category_memory" include="activity-board,flip,other," colour="165">';
 xmlToolbox += '        <category key="category_memory_eeprom" >';
 xmlToolbox += '            <block type="eeprom_read">';
@@ -1260,6 +1261,10 @@ xmlToolbox += '            </block>';
 xmlToolbox += '            <block type="sd_file_pointer"></block>';
 xmlToolbox += '        </category>';
 xmlToolbox += '    </category>';
+
+/*
+ * ANALOG/PULSE blocks
+ */
 xmlToolbox += '    <category key="category_analog-pulses" exclude="s3,heb,heb-wx," colour="185">';
 xmlToolbox += '        <category key="category_analog-pulses_pulse-in-out" exclude="s3,">';
 xmlToolbox += '            <block type="pulse_in"></block>';
@@ -1307,6 +1312,10 @@ xmlToolbox += '            <block type="mcp320x_read"></block>';
 xmlToolbox += '            <block type="mcp320x_set_vref"></block>';
 xmlToolbox += '        </category>';
 xmlToolbox += '    </category>';
+
+/*
+ * AUDIO blocks
+ */
 xmlToolbox += '    <category key="category_audio" exclude="s3," colour="185">';
 xmlToolbox += '        <category key="category_audio_freqout" >';
 xmlToolbox += '            <block type="base_freqout">';


### PR DESCRIPTION
Addresses issue #424.
The New Project board type drop down was not using the board type names as defined in the ProjectProfiles object. This caused a board-type mismatch when the project was loaded and consequently failed to identify the board type correctly. 