### PR TITLE
Issue #434 - Block generating NaN

### DIFF
--- a/src/modules/blockly/generators/propc/base.js
+++ b/src/modules/blockly/generators/propc/base.js
@@ -1588,9 +1588,15 @@ Blockly.propc.color_value_from = function() {
       this, 'GREEN_VALUE', Blockly.propc.ORDER_NONE) || '0';
   const blue = Blockly.propc.valueToCode(
       this, 'BLUE_VALUE', Blockly.propc.ORDER_NONE) || '0';
-  const output = 'getColorRRGGBB(' + red + ', ' + green + ', ' + blue + ')';
 
-  return [output, Blockly.propc.ORDER_NONE];
+  // Solo-#434
+  // Convert the RGB decimal values to a 24 bit hexadecimal value
+  const rgbToHex = (r, g, b) => '0x' + [r, g, b].map((x) => {
+    const hex = x.toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  }).join('');
+
+  return [rgbToHex(red, green, blue), Blockly.propc.ORDER_NONE];
 };
 
 /**

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -39,7 +39,7 @@
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.0-b2';
+export const APP_VERSION = '1.5.0-b3';
 
 /**
  * Constant string that represents the base, empty project header


### PR DESCRIPTION
Addresses issue #434 
The 'color_value_from' block code generator was returning a string representing a function call and not the RRGGBB hex value string the receiving block was expecting. The NaN was generated when the block tried to parse the string function as a hex value and failed. 

This update also bumps up the release to v1.5.0-b3.