### PR TITLE
Release v1.5.0-b5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blocklyprop-solo",
-  "version": "1.5.0-b4",
+  "version": "1.5.0-b5",
   "description": "A simplified implementation of Google's Blockly project configured to support Parallax robots and sensors.",
   "main": "index.js",
   "scripts": {

--- a/src/modules/blockly/generators/propc/base.js
+++ b/src/modules/blockly/generators/propc/base.js
@@ -1613,12 +1613,16 @@ Blockly.propc.color_value_from = function() {
       blueString === undefined) {
     // Solo-#434
     // Convert the RGB decimal values to a 24 bit hexadecimal value
-    const rgbToHex = (r, g, b) => '0x' + [r, g, b].map((x) => {
-      const hex = x.toString(16);
-      return hex.length === 1 ? '0' + hex : hex;
-    }).join('');
-
-    return [rgbToHex(red, green, blue), Blockly.propc.ORDER_NONE];
+    // const rgbToHex = (r, g, b) => '0x' + [r, g, b].map((x) => {
+    //   const hex = x.toString(16);
+    //   return hex.length === 1 ? '0' + hex : hex;
+    // }).join('');
+    //
+    // return [rgbToHex(red, green, blue), Blockly.propc.ORDER_NONE];
+    return [
+      `getColorRRGGBB(${red}, ${green}, ${blue})`,
+      Blockly.propc.ORDER_NONE,
+    ];
   }
 
   // Insert variables where they are found

--- a/src/modules/blockly/generators/propc/oled.js
+++ b/src/modules/blockly/generators/propc/oled.js
@@ -170,10 +170,10 @@ Blockly.propc.oled_initialize = function() {
       if (cogStartBlock && isExperimental.indexOf('volatile') > -1) {
         Blockly.propc.cog_setups_[this.myType] =
             [cogStartBlock, this.myType + ' = ' +
-            devType + '_init(' + pin.join(', ') + devWidthHeight + ');'];
+            devType + '_init(' + pin.join(', ') + devWidthHeight + ');\n'];
       } else {
         Blockly.propc.setups_[this.myType] = this.myType + ' = ' +
-            devType + '_init(' + pin.join(', ') + devWidthHeight + ');';
+            devType + '_init(' + pin.join(', ') + devWidthHeight + ');\n';
       }
     }
   }
@@ -1026,8 +1026,8 @@ Blockly.propc.oled_text_color = function() {
       backgroundColor = this.getFieldValue('BACKGROUND_COLOR_VALUE');
     }
     let code = '';
-    code += 'setTextColor(' + this.myType + ', ' + fontColor + ');';
-    code += 'setBgColor(' + this.myType + ', ' + backgroundColor + ');';
+    code += 'setTextColor(' + this.myType + ', ' + fontColor + ');\n';
+    code += 'setBgColor(' + this.myType + ', ' + backgroundColor + ');\n';
     return code;
   }
 };
@@ -1127,7 +1127,7 @@ Blockly.propc.oled_set_cursor = function() {
     const y = Blockly.propc.valueToCode(
         this, 'Y_POS', Blockly.propc.ORDER_NONE);
 
-    return 'setCursor(' + this.myType + ', ' + x + ', ' + y + ',0);';
+    return 'setCursor(' + this.myType + ', ' + x + ', ' + y + ',0);\n';
   }
 };
 
@@ -1172,7 +1172,7 @@ Blockly.propc.oled_print_text = function() {
   } else {
     const msg = Blockly.propc.valueToCode(
         this, 'MESSAGE', Blockly.propc.ORDER_NONE);
-    return 'drawText(' + this.myType + ', ' + msg + ');';
+    return 'drawText(' + this.myType + ', ' + msg + ');\n';
   }
 };
 
@@ -1224,7 +1224,7 @@ Blockly.propc.oled_print_number = function() {
     const num = Blockly.propc.valueToCode(
         this, 'NUMIN', Blockly.propc.ORDER_NONE);
     const type = this.getFieldValue('type');
-    return 'drawNumber(' + this.myType + ', ' + num + ', ' + type + ');';
+    return 'drawNumber(' + this.myType + ', ' + num + ', ' + type + ');\n';
   }
 };
 
@@ -1357,7 +1357,7 @@ Blockly.propc.oled_bitmap = function() {
       }
     }
     if (!initFound) {
-      Blockly.propc.setups_['sd_card'] = 'sd_mount(' + profile.sd_card + ');';
+      Blockly.propc.setups_['sd_card'] = 'sd_mount(' + profile.sd_card + ');\n';
     }
   }
 
@@ -1368,7 +1368,7 @@ Blockly.propc.oled_bitmap = function() {
       this, 'POS_Y', Blockly.propc.ORDER_NONE) || '0';
 
   return 'drawBitmap(' + this.myType + ', "' + filename + '.bmp", ' +
-      posX + ', ' + posY + ');';
+      posX + ', ' + posY + ');\n';
 };
 
 // TODO: What in going on here? Is swapping the height & width correct?

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -39,7 +39,7 @@
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.0-b4';
+export const APP_VERSION = '1.5.0-b5';
 
 /**
  * Constant string that represents the base, empty project header

--- a/src/style.css
+++ b/src/style.css
@@ -235,3 +235,12 @@ div#project div.wizard-container {
     display: inline;
     float: left;
 }
+
+/* Will-change memory consumption is too high. Budget limit is the document
+ * surface area multiplied by 3 (1237768 px). Occurrences of will-change over
+ * the budget will be ignored.
+ */
+.ace_gutter {
+    contain: strict;
+    will-change: transform !important;
+}


### PR DESCRIPTION
Correct an error in the color_value_from block that caused it to generate incorrect RRGGBB values from the provided inputs.

Add line feeds to sections of the code generator to help eliminate run-on source lines.

Address a browser warning triggered from the CSS defined in the ace package.