### PR TITLE
Patch fm 200609a

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blocklyprop-solo",
-  "version": "1.5.0-b5",
+  "version": "1.5.0-b6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8429,10 +8429,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-      "dev": true
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "jquery-validation": "^1.19.1",
     "js-cookie": "^2.2.1",
     "jszip": "^3.3.0",
-    "node-chartist": "^1.0.5"
+    "node-chartist": "^1.0.5",
+    "websocket-extensions": ">=0.1.4"
   },
   "devDependencies": {
     "@types/ace": "0.0.43",

--- a/src/modules/dialogs/import_project.js
+++ b/src/modules/dialogs/import_project.js
@@ -20,13 +20,11 @@
  *   DEALINGS IN THE SOFTWARE.
  */
 
-import Blockly from 'blockly/core';
-
 // eslint-disable-next-line camelcase
 import {page_text_label} from '../blockly/language/en/messages';
 import {LOCAL_PROJECT_STORE_NAME, TEMP_PROJECT_STORE_NAME} from '../constants';
-import {isProjectChanged, resetToolBoxSizing} from '../editor';
-import {uploadHandler, uploadMergeCode} from '../editor';
+import {isProjectChanged} from '../editor';
+import {uploadHandler, appendProjectCode} from '../editor';
 import {getProjectInitialState} from '../project';
 import {logConsoleMessage, utils} from '../utility';
 
@@ -65,12 +63,12 @@ export const importProjectDialog = {
     }
 
     // Set up element event handlers
-    importProjectModalAppendClick(); // Handle a click on the Append button
-    importProjectModalReplaceClick(); // Handle a click on the Replace button
-    importProjectModalCancelClick(); // Handle a click on the Cancel button
-    importProjectModalEscapeClick(); // Handle user clicking on the 'x' icon
-    importProjectModalOnFocus(); // Handle on focus event
-    importProjectModalSelectFileOnChange(); // Handle select file onChange
+    installAppendClickHandler(); // Handle a click on the Append button
+    installReplaceClickHandler(); // Handle a click on the Replace button
+    installCancelClickHandler(); // Handle a click on the Cancel button
+    installEscapeClickHandler(); // Handle user clicking on the 'x' icon
+    installOnFocusHandler(); // Handle on focus event
+    installFileOnChangeHandler(); // Handle select file onChange
 
     this.isEventHandler = true;
     logConsoleMessage(`Import Project dialog handlers initialized.`);
@@ -80,8 +78,6 @@ export const importProjectDialog = {
    *  Displays the open project modal.
    */
   show: function() {
-    importProjectFromStorage(); // This will be replaced with the code below
-
     if (!this.isEventHandler) {
       logConsoleMessage(`Initialize dialog event handlers first.`);
       return;
@@ -89,6 +85,7 @@ export const importProjectDialog = {
 
     logConsoleMessage(`Import Project dialog: show`);
     this.reset();
+
     // Save a copy of the original project in case the page gets reloaded
     if (getProjectInitialState() &&
         getProjectInitialState().name !== 'undefined') {
@@ -100,7 +97,7 @@ export const importProjectDialog = {
     // Has the project been revised. If it has, offer to persist it before
     // opening a new project
     if (!isProjectChanged()) {
-      importProject();
+      openImportProjectDialog();
     } else {
       const message =
           'The current project has been modified. Click Yes to\n' +
@@ -111,7 +108,7 @@ export const importProjectDialog = {
           message,
           function(result) {
             if (result) {
-              importProject();
+              openImportProjectDialog();
             }
           });
     }
@@ -126,62 +123,71 @@ export const importProjectDialog = {
     $('#import-project-dialog span').html(`Span import project`);
     // page_text_label['editor_import']);
 
-    // Hide the save-as button.
-    // $('#save-project-as, #save-as-btn').addClass('hidden');
-
     // Disable the import dialog Append and Replace buttons
-    logConsoleMessage(
-        `Disabling the Import Project Append and Replace buttons`);
-    document.getElementById('selectfile-replace').disabled = true;
-    document.getElementById('selectfile-append').disabled = true;
+    uiDisableButtons();
 
     // Clear any previous filename from the Input control
     clearInputFileName();
+
+    // Empty the temp browser storage bucket
+    window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
   },
 };
 
 /**
+ * Disable the dialog's Append and Replace buttons
+ */
+function uiDisableButtons() {
+  // Disable the Open button until we have a file to open
+  $('#selectfile-append').addClass('disabled');
+  $('#selectfile-replace').addClass('disabled');
+}
+
+/**
  * Import a project to append to or replace the current project
  */
-function importProject() {
-
+function openImportProjectDialog() {
+  $('#import-project-dialog').modal({keyboard: false, backdrop: 'static'});
 }
 
 /**
  * Set up onClick event handler for the Append button
  */
-function importProjectModalAppendClick() {
+function installAppendClickHandler() {
   $('#selectfile-append').on('click', function() {
     logConsoleMessage(`Import Append project button clicked`);
+    $('#import-project-dialog').modal('hide');
+    appendProjectCode();
 
     // Set the status message in the modal dialog
     // This only happens after the import project dialog has fired
-    if (importProjectDialog.isProjectFileValid === true) {
-      $('#selectfile-verify-valid').css('display', 'block');
-      document.getElementById('selectfile-replace').disabled = false;
-      document.getElementById('selectfile-append').disabled = false;
-      // uploadedXML = xmlString;
-    } else {
-      $('#selectfile-verify-notvalid').css('display', 'block');
-      document.getElementById('selectfile-replace').disabled = true;
-      document.getElementById('selectfile-append').disabled = true;
-    }
+    // if (importProjectDialog.isProjectFileValid === true) {
+    //   $('#selectfile-verify-valid').css('display', 'block');
+    //   document.getElementById('selectfile-replace').disabled = false;
+    //   document.getElementById('selectfile-append').disabled = false;
+    //   // uploadedXML = xmlString;
+    // } else {
+    //   $('#selectfile-verify-notvalid').css('display', 'block');
+    //   document.getElementById('selectfile-replace').disabled = true;
+    //   document.getElementById('selectfile-append').disabled = true;
+    // }
   });
 }
 
 /**
  * Set up the onClick event handler for the Replace button
  */
-function importProjectModalReplaceClick() {
+function installReplaceClickHandler() {
   $('#selectfile-replace').on('click', function() {
     logConsoleMessage(`Import Replace project button clicked`);
+    // Replace the existing project
   });
 }
 
 /**
  * Set up onClick event handler for the the 'x' control-
  */
-function importProjectModalCancelClick() {
+function installCancelClickHandler() {
   $('#selectfile-cancel-button').on('click', function() {
     logConsoleMessage(`Import Cancel project import button clicked`);
     clearInputFileName();
@@ -193,7 +199,7 @@ function importProjectModalCancelClick() {
  * @description  Trap the modal event that fires when the modal
  * window is closed when the user clicks on the 'x' icon.
  */
-function importProjectModalEscapeClick() {
+function installEscapeClickHandler() {
   $('#open-project-dialog').on('hidden.bs.modal', () => {
     clearInputFileName();
   });
@@ -202,137 +208,127 @@ function importProjectModalEscapeClick() {
 /**
  * Handle onFocus event
  */
-function importProjectModalOnFocus() {
+function installOnFocusHandler() {
   $('#selectfile').focus(function() {
     logConsoleMessage(`Resetting select file validation messages`);
     $('#selectfile-verify-notvalid').css('display', 'none');
     $('#selectfile-verify-valid').css('display', 'none');
     $('#selectfile-verify-boardtype').css('display', 'none');
   });
-
 }
+
 /**
  * Import project file from disk
  */
-export function importProjectFromStorage() {
-  logConsoleMessage(`Launching Import Project dialog process.`);
-
-  // Reject import request if the current project has
-  // not been persisted to storage
-  if (isProjectChanged()) {
-    logConsoleMessage(`Project change detected before import`);
-    utils.showMessage(
-        Blockly.Msg.DIALOG_UNSAVED_PROJECT,
-        Blockly.Msg.DIALOG_SAVE_BEFORE_ADD_BLOCKS);
-  } else {
-    // Reset the import/append modal to its default state when closed
-    const dialog = $('#import-project-dialog');
-    dialog.on('hidden.bs.modal', () => {
-      resetUploadImportDialog();
-    });
-    importProjectSetCallbacks();
-    window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
-    dialog.modal({keyboard: false, backdrop: 'static'});
-  }
-}
+// export function importProjectFromStorage() {
+//   logConsoleMessage(`Launching Import Project dialog process.`);
+//
+//   // Reject import request if the current project has
+//   // not been persisted to storage
+//   if (isProjectChanged()) {
+//     logConsoleMessage(`Project change detected before import`);
+//     utils.showMessage(
+//         Blockly.Msg.DIALOG_UNSAVED_PROJECT,
+//         Blockly.Msg.DIALOG_SAVE_BEFORE_ADD_BLOCKS);
+//   } else {
+//     // Reset the import/append modal to its default state when closed
+//     const dialog = $('#import-project-dialog');
+//     dialog.on('hidden.bs.modal', () => {
+//       resetUploadImportDialog();
+//     });
+//     importProjectSetCallbacks();
+//     window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
+//     dialog.modal({keyboard: false, backdrop: 'static'});
+//   }
+// }
 
 /**
  * Handle Select File onChange event
  */
-function importProjectModalSelectFileOnChange() {
+function installFileOnChangeHandler() {
   // Attach handler to process a project file when it is selected in the
   // Import Project File hamburger menu item.
   const selectControl = document.getElementById('selectfile');
-  selectControl.addEventListener('change', (e) => {
-    logConsoleMessage(`SelectFile onChange event: ${e.message}`);
-    uploadHandler(e.target.files);
-    logConsoleMessage(`We should expect to eventually see a project file.`);
-    // const localProject = projectJsonFactory(
-    //     JSON.parse(
-    //         window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)));
-    // setupWorkspace(localProject, function() {
-    //   window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
-    // });
-    //
-    // // Create an instance of the CodeEditor class
-    // codeEditor = new CodeEditor(localProject.boardType.name);
-    // if (!codeEditor) {
-    //   console.log('Error allocating CodeEditor object');
-    // }
-    //
-    // // Set the compile toolbar buttons to unavailable
-    // propToolbarButtonController();
+  selectControl.addEventListener('change', (event) => {
+    logConsoleMessage(`SelectFile onChange event: ${event.message}`);
+    if (event.target.files[0] && event.target.files[0].name.length > 0) {
+      uploadHandler(event.target.files, [
+        'selectfile-replace',
+        'selectfile-append',
+      ]);
+    } else {
+      uiDisableButtons();
+    }
   });
-
 }
 /**
  * Set up the dialog "Choose File" onChange handler
  */
-function importProjectSetCallbacks() {
-  logConsoleMessage(`Setting Import Project callbacks`);
-  // Attach handler to process a project file when it is selected in the
-  // Import Project File hamburger menu item.
-  const selectControl = document.getElementById('selectfile');
-  selectControl.addEventListener('change', (e) => {
-    logConsoleMessage(`SelectFile onChange event: ${e.message}`);
-    uploadHandler(e.target.files);
-    logConsoleMessage(`We should expect to eventually see a project file.`);
-    // const localProject = projectJsonFactory(
-    //     JSON.parse(
-    //         window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)));
-    // setupWorkspace(localProject, function() {
-    //   window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
-    // });
-    //
-    // // Create an instance of the CodeEditor class
-    // codeEditor = new CodeEditor(localProject.boardType.name);
-    // if (!codeEditor) {
-    //   console.log('Error allocating CodeEditor object');
-    // }
-    //
-    // // Set the compile toolbar buttons to unavailable
-    // propToolbarButtonController();
-  });
-  // Clear the select project file dialog event handler
-  $('#selectfile-cancel-button').on('click', () => {
-    cancelImportProjectHandler();
-  });
-
-  // Import project modal dialog Replace Project button onClick event handler
-  $('#selectfile-replace').on('click', () => uploadMergeCode(false));
-
-  // Import project modal dialog Append Project button onClick event handler
-  $('#selectfile-append').on('click', () => uploadMergeCode(true));
-}
+// function importProjectSetCallbacks() {
+//   logConsoleMessage(`Setting Import Project callbacks`);
+//   // Attach handler to process a project file when it is selected in the
+//   // Import Project File hamburger menu item.
+//   const selectControl = document.getElementById('selectfile');
+//   selectControl.addEventListener('change', (e) => {
+//     logConsoleMessage(`SelectFile onChange event: ${e.message}`);
+//     uploadHandler(e.target.files);
+//     logConsoleMessage(`We should expect to eventually see a project file.`);
+//     // const localProject = projectJsonFactory(
+//     //     JSON.parse(
+//     //         window.localStorage.getItem(LOCAL_PROJECT_STORE_NAME)));
+//     // setupWorkspace(localProject, function() {
+//     //   window.localStorage.removeItem(LOCAL_PROJECT_STORE_NAME);
+//     // });
+//     //
+//     // // Create an instance of the CodeEditor class
+//     // codeEditor = new CodeEditor(localProject.boardType.name);
+//     // if (!codeEditor) {
+//     //   console.log('Error allocating CodeEditor object');
+//     // }
+//     //
+//     // // Set the compile toolbar buttons to unavailable
+//     // propToolbarButtonController();
+//   });
+//   // Clear the select project file dialog event handler
+//   $('#selectfile-cancel-button').on('click', () => {
+//     cancelImportProjectHandler();
+//   });
+//
+//   // Import project modal dialog Replace Project button onClick event handler
+//   $('#selectfile-replace').on('click', () => appendProjectCode(false));
+//
+//   // Import project modal dialog Append Project button onClick event handler
+//   $('#selectfile-append').on('click', () => appendProjectCode(true));
+// }
 
 /**
  * Reset the upload/import modal window to defaults after use
  */
-function resetUploadImportDialog() {
-  // reset the title of the modal
-  $('import-project-dialog-title').html(page_text_label['editor_import']);
-
-  // hide "append" button
-  $('#selectfile-append').removeClass('hidden');
-
-  // change color of the "replace" button to blue and change text to "Open"
-  $('#selectfile-replace')
-      .removeClass('btn-primary')
-      .addClass('btn-danger')
-      .html(page_text_label['editor_button_replace']);
-
-  // reset the blockly toolbox sizing to ensure it renders correctly:
-  // eslint-disable-next-line no-undef
-  resetToolBoxSizing(100);
-}
+// function resetUploadImportDialog() {
+//   // reset the title of the modal
+//   $('import-project-dialog-title').html(page_text_label['editor_import']);
+//
+//   // hide "append" button
+//   $('#selectfile-append').removeClass('hidden');
+//
+//   // change color of the "replace" button to blue and change text to "Open"
+//   $('#selectfile-replace')
+//       .removeClass('btn-primary')
+//       .addClass('btn-danger')
+//       .html(page_text_label['editor_button_replace']);
+//
+//   // reset the blockly toolbox sizing to ensure it renders correctly:
+//   // eslint-disable-next-line no-undef
+//   resetToolBoxSizing(100);
+// }
 
 /**
  * Import Project Cancel button click event handler
  */
-function cancelImportProjectHandler() {
-  logConsoleMessage(`The import has been cancelled.`);
-  window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
-}
+// function cancelImportProjectHandler() {
+//   logConsoleMessage(`The import has been cancelled.`);
+//   window.localStorage.removeItem(TEMP_PROJECT_STORE_NAME);
+// }
 
 /**
  * Clear the file name from the select file Input control

--- a/src/modules/dialogs/open_project.js
+++ b/src/modules/dialogs/open_project.js
@@ -140,6 +140,7 @@ export const openProjectDialog = {
   reset: function() {
     // set title to Open file
     $('#open-project-dialog-title').html(page_text_label['editor_open']);
+    uiDisableOpenButton();
 
     // Clear any previous filename
     const filenameInput = $('#open-project-select-file');
@@ -151,6 +152,14 @@ export const openProjectDialog = {
     }
   },
 };
+
+/**
+ * Disable the dialog's Open button
+ */
+function uiDisableOpenButton() {
+  // Disable the Open button until we have a file to open
+  $('#open-project-select-file-open').addClass('disabled');
+}
 
 /**
  * Open a modal dialog to prompt user for the project file name
@@ -169,16 +178,6 @@ function openProjectDialogWindow() {
  * Handle the onChange event for the file selection dialog
  */
 function setSelectedFileOnChange() {
-  // const inputElement = document.getElementById('open-project-select-file');
-  // inputElement.addEventListener('change', function() {
-  //   const fileList = this.files; /* now you can work with the file list */
-  //   logConsoleMessage(`${fileList}`);
-  // },
-  // false);
-
-  // Attach handler to process a project file when it is selected in the
-  // Open Project toolbar button
-
   $('#open-project-select-file').on('change', function(event) {
     logConsoleMessage(`File selector has changed`);
     if (event.target.files[0] && event.target.files[0].name.length > 0) {
@@ -186,9 +185,10 @@ function setSelectedFileOnChange() {
           `OpenProject onChange event: ${event.target.files[0].name}`);
       // Load project into browser storage and let the modal event handler
       // decide what to do with it
-      uploadHandler(event.target.files, function(fileFlag) {
-        logConsoleMessage(`Project file load state is: ${fileFlag}`);
-      });
+      uploadHandler(event.target.files, ['open-project-select-file-open']);
+    } else {
+      // Disable the Open button
+      uiDisableOpenButton();
     }
   });
 }

--- a/src/modules/dialogs/open_project.js
+++ b/src/modules/dialogs/open_project.js
@@ -100,6 +100,7 @@ export const openProjectDialog = {
    *  Displays the open project modal.
    */
   show: function() {
+    logProjectName();
     if (!this.isEventHandler) {
       logConsoleMessage(`Initialize dialog event handlers first.`);
       return;
@@ -165,6 +166,7 @@ function uiDisableOpenButton() {
  * Open a modal dialog to prompt user for the project file name
  */
 function openProjectDialogWindow() {
+  logProjectName();
   // Open the modal dialog. The event handlers will take it from here.
   logConsoleMessage(`Open Project dialog is opening`);
   $('#open-project-dialog').modal({
@@ -179,6 +181,7 @@ function openProjectDialogWindow() {
  */
 function setSelectedFileOnChange() {
   $('#open-project-select-file').on('change', function(event) {
+    logProjectName();
     logConsoleMessage(`File selector has changed`);
     if (event.target.files[0] && event.target.files[0].name.length > 0) {
       logConsoleMessage(
@@ -216,6 +219,7 @@ function setSelectedFileOnChange() {
  */
 function openProjectModalOpenClick() {
   $('#open-project-select-file-open').on('click', () => {
+    logProjectName();
     logConsoleMessage(`User elected to open the project`);
     logConsoleMessage(`Closing the 'Open Project' dialog`);
     $('#open-project-dialog').modal('hide');
@@ -227,6 +231,7 @@ function openProjectModalOpenClick() {
       const project = projectJsonFactory(JSON.parse(projectJson));
       if (project) {
         insertProject(project);
+        logProjectName();
         return;
       }
     }
@@ -238,6 +243,7 @@ function openProjectModalOpenClick() {
         () => {
           logConsoleMessage(`Possible project load failure`);
         });
+    logProjectName();
   });
 }
 
@@ -273,6 +279,7 @@ function openProjectModalOpenClick() {
  */
 function openProjectModalCancelClick() {
   $('#open-project-select-file-cancel').on('click', () => {
+    logProjectName();
     logConsoleMessage(`Open Dialog: cancelled`);
     // Dismiss the modal in the UX
     $('#open-project-dialog').modal('hide');
@@ -297,6 +304,7 @@ function openProjectModalCancelClick() {
  */
 function openProjectModalEscapeClick() {
   $('#open-project-dialog').on('hidden.bs.modal', () => {
+    logProjectName();
     clearCookie();
   });
 }
@@ -308,4 +316,12 @@ function clearCookie() {
   if (Cookies.get('action')) {
     Cookies.remove('action');
   }
+}
+
+/**
+ * Write the current project name to the console log
+ */
+function logProjectName() {
+  logConsoleMessage(
+      `Current project name is:=> ${getProjectInitialState().name}`);
 }

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -85,7 +85,6 @@ function getProjectInitialState() {
   return projectInitialState;
 }
 
-
 /**
  * Set the project state from an existing project object
  * @param {Project} project
@@ -184,7 +183,9 @@ class Project {
   constructor(name, description, board, projectType,
       code, created, modified, timestamp, isDefault = false) {
     // Preserve the instance if one is not set
-    projectInitialState = this;
+    if (!projectInitialState) {
+      projectInitialState = this;
+    }
 
     this.name = (name) ? name : '';
     this.description = (description) ? description : '';
@@ -295,7 +296,7 @@ class Project {
     if (isDefault) {
       this.projectData = this.getDetails();
     }
-  }
+  } // End of constructor
 
   /**
      * Get all of the project details in one function call. This is
@@ -338,13 +339,11 @@ class Project {
 
   /**
    * Returns a reference to the project data encapsulated into a single object
-   * @return {
-   *   {
+   * @return {{
    *     shared: *, private: *, boardType: *, code: *, created: *,
    *     description: *, type: *, name: *, modified: *, descriptionHtml: *,
    *     id: *, user: *, yours: *, timestamp: *
-   *   }
-   * }
+   *   }}
    */
 
   /**


### PR DESCRIPTION
Large refactor of import_project module to fully manage the import dialog and import project process.
Updates to disable project load and import buttons when a project file has not been selected.
Rename uploadMergeCode(append) to appendProjectCode() because merging code is all it really does.
Correct error in Project class constructor that was replacing the default project with the one being instantiated in the constructor.
Update websockets-extension package to correct a security issue.
