### PR TITLE
Solo-473 - Add SD_init block to the toolbox menu for Flip board type.

### DIFF
--- a/src/modules/toolbox_data.js
+++ b/src/modules/toolbox_data.js
@@ -1114,6 +1114,8 @@ xmlToolbox += '            <block type="heb_count_contacts"></block>';
 xmlToolbox += '            <block type="heb_erase_all_contacts"></block>';
 xmlToolbox += '        </category>';
 xmlToolbox += '        <category key="category_memory_sdcard" include="heb-wx,">';
+// Solo-473 Add SD_Init block to menu for Flip board type
+xmlToolbox += '            <block type="sd_init" exclude="activity-board,"></block>';
 xmlToolbox += '            <block type="sd_open"></block>';
 xmlToolbox += '            <block type="sd_read">';
 xmlToolbox += '                <value name="SIZE">';


### PR DESCRIPTION
Addresses issue #473 

The toolbox menu for Memory-> SD Cards does not contain the SD_Init block for the Flip board type. This patch corrects the issue by adding the missing block to the toolbox Memory-SD Cards menu.