### PR TITLE
Solo-485 - Rebuild Blocky div on toolbar change.

### DIFF
--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -1526,12 +1526,16 @@ function initToolbox(profileName) {
     },
   };
 
-  // Provide configuration options and inject this into the content_blocks div
-  if (document.getElementsByClassName('blocklyToolboxDiv').length === 0) {
-    injectedBlocklyWorkspace = Blockly.inject(
-        'content_blocks',
-        blocklyOptions);
+  // Solo-485 This is a sledgehammer approach to updating the toolbox. If the
+  // toolbox is already defined, destroy the Blockly canvas inner HTML and
+  // rebuild the whole thing from scratch, with the correct toolbox
+  if (document.getElementsByClassName('blocklyToolboxDiv').length !== 0) {
+    document.getElementById('content_blocks').innerHTML = '';
   }
+
+  injectedBlocklyWorkspace = Blockly.inject(
+      'content_blocks',
+      blocklyOptions);
 
   initializeBlockly(Blockly);
 


### PR DESCRIPTION
Addresses issue Solo #485 
It appears that there is no method within the Blockly core at v2019.722x that supports rebuilding the entire toolbox. The alternative implemented here is to remove the HTML created from the Blockly.Inject call and rebuild the canvas and toolbox with a new call to Blockly.Inject.
