### PR TITLE
Patch for Solo-490 issue

### DIFF
--- a/src/modules/blockly/generators/propc/gpio.js
+++ b/src/modules/blockly/generators/propc/gpio.js
@@ -32,6 +32,7 @@
 'use strict';
 
 import Blockly from 'blockly/core';
+import * as Sentry from '@sentry/browser';
 
 import {getDefaultProfile, getProjectInitialState} from '../../../project';
 import {colorPalette} from '../propc';
@@ -1511,13 +1512,24 @@ Blockly.propc.fb360_status = function() {
 Blockly.Blocks.ab_volt_in = {
   helpUrl: Blockly.MSG_ANALOG_PULSES_HELPURL,
   init: function() {
-    const profile = getDefaultProfile();
+    let profile = getDefaultProfile();
+
+    if (profile.analog.length === 0) {
+      const project = getProjectInitialState();
+      const message = `ABVoltsIn: ` +
+          `Empty profile analog list detected for board type ` +
+          `'${project.boardType.name}'.`;
+
+      Sentry.captureMessage(message);
+      console.log(message);
+      profile = ['A0', '0'];
+    }
+
     this.setTooltip(Blockly.MSG_AB_VOLT_IN_TOOLTIP);
     this.setColour(colorPalette.getColor('io'));
     this.appendDummyInput()
         .appendField('A/D channel')
-        .appendField(new Blockly.FieldDropdown(
-            profile.analog), 'CHANNEL')
+        .appendField(new Blockly.FieldDropdown(profile.analog), 'CHANNEL')
         .appendField('read (0-5V) in volt-100ths');
     this.setOutput(true, 'Number');
     this.setPreviousStatement(false, null);

--- a/src/modules/blockly/generators/propc/sensors.js
+++ b/src/modules/blockly/generators/propc/sensors.js
@@ -32,6 +32,7 @@
 'use strict';
 
 import Blockly from 'blockly/core';
+import * as Sentry from '@sentry/browser';
 
 import {getDefaultProfile, getProjectInitialState} from '../../../project';
 import {colorPalette} from '../propc.js';
@@ -158,7 +159,19 @@ Blockly.propc.sensor_ping = function() {
 Blockly.Blocks.joystick_input_yaxis = {
   helpUrl: Blockly.MSG_JOYSTICK_HELPURL,
   init: function() {
-    const profile = getDefaultProfile();
+    let profile = getDefaultProfile();
+
+    if (profile.analog.length === 0) {
+      const project = getProjectInitialState();
+      const message = `JoystickInputYAxis: ` +
+          `Empty profile analog list detected for board type ` +
+          `'${project.boardType.name}'.`;
+
+      Sentry.captureMessage(message);
+      console.log(message);
+      profile = ['A0', '0'];
+    }
+
     this.chan = ['x', 'X'];
     if (this.type === 'joystick_input_yaxis') {
       this.chan = ['y', 'Y'];


### PR DESCRIPTION
Addresses Solo #490 
This error is caused by a failed attempt to access a member of the profile.analog array. This can only happen if the array is empty. There is insufficient data to reach a conclusion on the exact cause. The analog array could have been truncated or the board type is set to a board that has an empty profile.analog array.

To address the uncertainty, Sentry messages are added to the reported methods to help us determine the board type and the state of the profile.analog array when this condition occurs.