### PR TITLE
Update version and correct code generator output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blocklyprop-solo",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A simplified implementation of Google's Blockly project configured to support Parallax robots and sensors.",
   "main": "index.js",
   "scripts": {

--- a/src/modules/blockly/generators/propc/s3.js
+++ b/src/modules/blockly/generators/propc/s3.js
@@ -793,14 +793,16 @@ Blockly.Blocks.scribbler_drive = {
 };
 
 /**
- *
+ * C code generator for the Scribbler_Drive block
  * @return {string}
  */
 Blockly.propc.scribbler_drive = function() {
-  return 's3_simpleDrive(S3_' +
-      this.getFieldValue('DRIVE_DIRECTION') + ', ' +
-      this.getFieldValue('DRIVE_ANGLE').trim() +
-      this.getFieldValue('DRIVE_SPEED') + ');\n';
+  // Direction is either a space ' ' or a minus sign '-'
+  const direction = this.getFieldValue('DRIVE_DIRECTION');
+  const angle = this.getFieldValue('DRIVE_ANGLE').trim();
+  const speed = this.getFieldValue('DRIVE_SPEED');
+
+  return `s3_simpleDrive(S3_${angle},${direction}${speed});\n`;
 };
 
 /**

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,7 +44,7 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.1';
+export const APP_VERSION = '1.5.2';
 
 /**
  * Constant string that represents the base, empty project header


### PR DESCRIPTION
Addresses issue #493 

The C code generator was swapping two of the three outputs and creating code that would not compile. Refactored the method to generate the correct output.

Update version to 1.5.2 in the development branch.