### PR TITLE
Address solo issue #507.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blocklyprop-solo",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A simplified implementation of Google's Blockly project configured to support Parallax robots and sensors.",
   "main": "index.js",
   "scripts": {

--- a/src/modules/blockly/generators/propc/aliaes.js
+++ b/src/modules/blockly/generators/propc/aliaes.js
@@ -57,6 +57,9 @@ Blockly.propc.string_sprint_multiple = Blockly.propc.console_print_multiple;
 Blockly.propc.fb360_set = Blockly.propc.fb360_setup;
 
 /* OLED */
+Blockly.Blocks.oled_get_max_width = Blockly.Blocks.oled_get_max_height;
+Blockly.propc.oled_get_max_width = Blockly.propc.oled_get_max_height;
+
 Blockly.propc.oled_print_multiple = Blockly.propc.console_print_multiple;
 
 /* E-PAPER */

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,7 +44,7 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.3';
+export const APP_VERSION = '1.5.4';
 
 /**
  * Constant string that represents the base, empty project header


### PR DESCRIPTION
Release Solo v1.5.4
Add in two block aliases that were inadvertently omitted in the last release.
