### PR TITLE
Solo 510

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blocklyprop-solo",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A simplified implementation of Google's Blockly project configured to support Parallax robots and sensors.",
   "main": "index.js",
   "scripts": {

--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -24,7 +24,7 @@ import Blockly from 'blockly/core';
 import * as Chartist from 'chartist';
 import {saveAs} from 'file-saver';
 
-import {baudrate, getComPort} from './client_connection';
+import {getComPort} from './client_connection';
 import {clientService, serviceConnectionTypes} from './client_service';
 import {loadToolbox, prettyCode} from './editor';
 import {CodeEditor} from './code_editor';
@@ -474,8 +474,9 @@ export function serialConsole() {
       connection.onopen = function() {
         connString = '';
         connStrYet = false;
-        connection.send('+++ open port ' + getComPort() +
-            (baudrate ? ' ' + baudrate : ''));
+        const baudRate = clientService.terminalBaudRate > 0 ?
+            ` ${clientService.terminalBaudRate}`: '';
+        connection.send(`+++ open port ${getComPort()} ${baudRate}`);
         clientService.activeConnection = connection;
       };
 
@@ -494,7 +495,8 @@ export function serialConsole() {
           pTerm.display(charBuffer);
         } else {
           connString += charBuffer;
-          if (connString.indexOf(baudrate.toString(10)) > -1) {
+          if (connString.indexOf(
+              clientService.terminalBaudRate.toString(10)) > -1) {
             connStrYet = true;
             displayTerminalConnectionStatus(connString.trim());
           } else {
@@ -539,7 +541,7 @@ export function serialConsole() {
       type: 'serial-terminal',
       outTo: 'terminal',
       portPath: getComPort(),
-      baudrate: baudrate.toString(10),
+      baudrate: clientService.terminalBaudRate.toString(10),
       msg: 'none',
       action: 'open',
     };
@@ -619,8 +621,10 @@ export function graphingConsole() {
 
       // When the connection is open, open com port
       connection.onopen = function() {
-        connection.send('+++ open port ' + getComPort() +
-            (baudrate ? ' ' + baudrate : ''));
+        const baudRate = clientService.terminalBaudRate > 0 ?
+            ` ${clientService.terminalBaudRate}`: '';
+        connection.send(`+++ open port ${getComPort()} ${baudRate}`);
+
         graphStartStop('start');
       };
 
@@ -636,7 +640,8 @@ export function graphingConsole() {
           graphNewData(charBuffer);
         } else {
           connString += charBuffer;
-          if (connString.indexOf(baudrate.toString(10)) > -1) {
+          if (connString.indexOf(
+              clientService.terminalBaudRate.toString(10)) > -1) {
             connStrYet = true;
             displayTerminalConnectionStatus(connString.trim());
           } else {
@@ -659,7 +664,7 @@ export function graphingConsole() {
         type: 'serial-terminal',
         outTo: 'graph',
         portPath: getComPort(),
-        baudrate: baudrate.toString(10),
+        baudrate: clientService.terminalBaudRate.toString(10),
         msg: 'none',
         action: 'open',
       };

--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -31,12 +31,6 @@ import {logConsoleMessage, utils} from './utility';
 import {propToolbarButtonController} from './toolbar_controller';
 import {getPropTerminal} from './prop_term';
 
-/**
- * Terminal baudrate setting
- *
- * @type {number}
- */
-export const baudrate = 115200;
 
 /**
  * This is the number of milliseconds that can go by between port updates
@@ -178,7 +172,7 @@ function establishBPLauncherConnection() {
        */
       const wsMessage = {
         type: 'hello-browser',
-        baud: baudrate,
+        baud: clientService.terminalBaudRate,
       };
       clientService.activeConnection = connection;
       connection.send(JSON.stringify(wsMessage));

--- a/src/modules/client_service.js
+++ b/src/modules/client_service.js
@@ -23,7 +23,7 @@
 
 import {logConsoleMessage} from './utility';
 import {PropTerm} from './prop_term';
-import {baudrate, getComPort} from './client_connection';
+import {getComPort} from './client_connection';
 
 /**
  * These are the permitted states of the clientService.type property
@@ -154,6 +154,23 @@ export const clientService = {
    *  are indicative of traffic received from the client.
    */
   lastPortUpdate_: 0,
+
+  /**
+   * The baud rate that will be used to when establishing a terminal session.
+   * @type {number}
+   * @description The default baud rate is compatible with all devices except
+   * the Scribbler series of robots. The Scribbler robots use 9600 baud.
+   */
+  terminalBaudRate: 115200,
+
+  /**
+   * Setter for terminal baud rate
+   * @param {number} baudRate
+   */
+  setTerminalBaudRate: function(baudRate) {
+    logConsoleMessage(`Setting terminal baud rate to: ${baudRate}`);
+    this.terminalBaudRate = baudRate;
+  },
 
   /**
    * Set a custom URL used to contact the BP Launcher
@@ -347,6 +364,7 @@ export const clientService = {
  */
 export function initTerminal() {
   logConsoleMessage(`Init terminal communications`);
+
   new PropTerm(
       document.getElementById('serial_console'),
 
@@ -359,8 +377,7 @@ export function initTerminal() {
             type: 'serial-terminal',
             outTo: 'terminal',
             portPath: getComPort(),
-            // TODO: Correct baudrate reference
-            baudrate: baudrate.toString(10),
+            baudrate: clientService.terminalBaudRate.toString(10),
             msg: (clientService.rxBase64 ?
                 btoa(characterToSend) : characterToSend),
             action: 'msg',

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,7 +44,7 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.4';
+export const APP_VERSION = '1.5.5';
 
 /**
  * Constant string that represents the base, empty project header

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -537,7 +537,13 @@ function initDefaultProject() {
   // window.location.href = 'index.html' + getAllUrlParameters();
   // TODO: New Default Project
   const defaultProject = buildDefaultProject();
-  setProjectInitialState(defaultProject);
+  const myProject = setProjectInitialState(defaultProject);
+
+  // Update the terminal serial port baud rate
+  if (myProject) {
+    clientService.setTerminalBaudRate(myProject.boardType.baudrate);
+  }
+
   // Create a new nudge timer
   const myTime = new NudgeTimer(0);
   // Set the callback
@@ -592,6 +598,11 @@ function setupWorkspace(data, callback) {
     // Something has gone sideways
     throw new Error('Unable to load the project.');
   }
+  // Update the terminal serial port baud rate
+  if (project) {
+    clientService.setTerminalBaudRate(project.boardType.baudrate);
+  }
+
 
   setDefaultProfile(project.boardType);
 
@@ -1843,7 +1854,12 @@ export function createNewProject() {
     clearProjectInitialState();
 
     // Update the Blockly core
-    setProjectInitialState(newProject);
+    const myProject = setProjectInitialState(newProject);
+
+    // Update the terminal serial port baud rate
+    if (myProject) {
+      clientService.setTerminalBaudRate(myProject.boardType.baudrate);
+    }
     // Create a new nudge timer
     const myTime = new NudgeTimer(0);
     // Set the callback
@@ -1879,7 +1895,12 @@ export function insertProject(project) {
   try {
     // project.stashProject(LOCAL_PROJECT_STORE_NAME);
     clearProjectInitialState();
-    setProjectInitialState(project);
+    const myProject = setProjectInitialState(project);
+
+    // Update the terminal serial port baud rate
+    if (myProject) {
+      clientService.setTerminalBaudRate(myProject.boardType.baudrate);
+    }
 
     if (!project.isTimerSet()) {
       // Create a new nudge timer

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -948,6 +948,7 @@ const ProjectProfiles = {
     description: 'Board type is unknown',
     digital: [['P0', '0']],
     analog: [['A0', '0']],
+    baudrate: 115200,
     saves_to: [],
   },
 };


### PR DESCRIPTION
Addresses issue #510 
This patch implements a new TerminalBaudRate property that replaces the exported global constant 'baudrate'. The code that creates or loads projects now sets this terminal baud rate from the board type baud rate definition.
Added a console.log to enumerate the terminal baud rate on every project transition.