### PR TITLE
Solo-521. Remove regex expression. Refactor code block.

### DIFF
--- a/src/modules/blockly/generators/propc/communicate.js
+++ b/src/modules/blockly/generators/propc/communicate.js
@@ -836,23 +836,23 @@ Blockly.propc.console_print_multiple = function() {
       orIt = '0';
     }
 
+    // Get the resulting code from Blockly core
+    const result = Blockly.propc.valueToCode(
+        this, 'PRINT' + i, Blockly.propc.ORDER_NONE) || orIt;
+
     if (!this.getFieldValue('TYPE' + i).includes('float point  divide by')) {
-      varList += ', ' + (Blockly.propc.valueToCode(
-          this,
-          'PRINT' + i,
-          Blockly.propc.ORDER_NONE).replace(/%/g, '%%') || orIt);
+      varList += ', ' + result;
     } else {
-      varList += ', ((float) ' + (Blockly.propc.valueToCode(
-          this,
-          'PRINT' + i,
-          Blockly.propc.ORDER_NONE) || orIt) +
-                    ') / ' + this.getFieldValue('DIV' + i) + '.0';
+      varList += ', ((float) ' + result + ') / ' +
+          this.getFieldValue('DIV' + i) + '.0';
     }
     i++;
   }
+
   if (this.getFieldValue('ck_nl') === 'TRUE') {
     code += '\\r';
   }
+
   code += '"' + varList + ');\n';
 
   // TODO: Replace .getAllBlocks() with getAllBlocksByType()


### PR DESCRIPTION
Removed an extraneous regex that was converting a single '%' to a double '%'. Refactor the affected block to lift redundant code from the if/else statement.


Addresses issue #521 
