### PR TITLE
New sd_close block, deprecated block warning system

### DIFF
--- a/src/modules/blockly/generators/propc.js
+++ b/src/modules/blockly/generators/propc.js
@@ -31,6 +31,7 @@
 import Blockly from 'blockly/core.js';
 import {getDefaultProfile} from '../../project.js';
 import {isExperimental} from '../../utility';
+import {WarnDeprecatedBlocks} from '../../constants';
 
 Blockly.propc = new Blockly.Generator('propc');
 Blockly.HSV_SATURATION = 0.75;
@@ -42,6 +43,7 @@ Blockly.RTL = false;
  */
 const colorPalette = {
   defaultColors: {
+    'deprecated': 60,
     'input': 140,
     'output': 165,
     'io': 185,
@@ -57,6 +59,7 @@ const colorPalette = {
     'system': 320,
   },
   grayscaleColors: {
+    'deprecated': '#a85c39',
     'input': '#AAAAAA',
     'output': '#222222',
     'io': '#333333',
@@ -1132,5 +1135,8 @@ Blockly.BlockSvg.prototype.bumpNeighbours = function() {
   }
 };
 
+const isDeprecatedBlockWarningEnabled = function() {
+  return WarnDeprecatedBlocks;
+};
 
-export {colorPalette};
+export {colorPalette, isDeprecatedBlockWarningEnabled};

--- a/src/modules/blockly/generators/propc/sd_card.js
+++ b/src/modules/blockly/generators/propc/sd_card.js
@@ -22,7 +22,7 @@
 
 import Blockly from 'blockly/core';
 import {getDefaultProfile, getProjectInitialState} from '../../../project';
-import {colorPalette} from '../propc';
+import {colorPalette, isDeprecatedBlockWarningEnabled} from '../propc';
 
 const SdInitMissingMessage =
     '/** WARNING: You must use a SD initialize block at the' +
@@ -34,6 +34,9 @@ const SdOpenMissingMessage =
 
 /**
  * SD Card Initialization
+ *
+ * This block does not appear in the toolbox but is referenced by other blocks.
+ *
  * @type {{
  *  init: Blockly.Blocks.sd_init.init,
  *  helpUrl: string
@@ -98,9 +101,18 @@ Blockly.propc.sd_init = function() {
  */
 Blockly.Blocks.sd_open = {
   helpUrl: Blockly.MSG_SD_HELPURL,
+
   init: function() {
     this.setTooltip(Blockly.MSG_SD_OPEN_TOOLTIP);
-    this.setColour(colorPalette.getColor('output'));
+
+    // Block is being replaced with newer functionality
+    if (isDeprecatedBlockWarningEnabled()) {
+      this.setColour(colorPalette.getColor('deprecated'));
+      this.setWarningText('A newer version of this block is available.');
+    } else {
+      this.setColour(colorPalette.getColor('output'));
+    }
+
     this.appendDummyInput('MODE')
         .appendField('SD file open')
         .appendField(new Blockly.FieldTextInput(
@@ -149,9 +161,16 @@ Blockly.Blocks.sd_open = {
 
 /**
  * SD Card Open C code generator
+ *
+ * NOTE:
+ * The sd_init block is automatically included when the board profile includes
+ * pin assignments for a board-mounted sd card reader.
+ *
  * @return {string}
  */
 Blockly.propc.sd_open = function() {
+  // Verify that the sd_init is included in the project. For specific board
+  // type, the setting are derived from the board profile.
   const initSdBlock = Blockly.getMainWorkspace().getBlocksByType(
       'sd_init', false);
   if (initSdBlock.length === 0 || !initSdBlock[0].isEnabled()) {
@@ -167,7 +186,13 @@ Blockly.propc.sd_open = function() {
 
   const filename = this.getFieldValue('FILENAME');
   const mode = this.getFieldValue('MODE');
-  return `fp = fopen("${filename}","${mode}");\n`;
+
+  let code = `fp = fopen("${filename}","${mode}");\n`;
+  if (isDeprecatedBlockWarningEnabled()) {
+    code = `\n/** NOTICE **\n  * A newer version of this block ` +
+        `is available.\n  **/\n` + code;
+  }
+  return code;
 };
 
 /**
@@ -183,6 +208,7 @@ Blockly.propc.sd_open = function() {
  */
 Blockly.Blocks.sd_read = {
   helpUrl: Blockly.MSG_SD_HELPURL,
+
   init: function() {
     this.setTooltip(Blockly.MSG_SD_READ_TOOLTIP);
     this.setColour(colorPalette.getColor('output'));
@@ -203,6 +229,7 @@ Blockly.Blocks.sd_read = {
     }
     this.setSdMode(mode);
   },
+
   setSdMode: function(mode) {
     let connectedBlock = null;
 
@@ -213,9 +240,11 @@ Blockly.Blocks.sd_read = {
       }
       this.removeInput('SIZE');
     }
+
     if (this.getInput('VALUE')) {
       this.removeInput('VALUE');
     }
+
     if (mode === 'fwrite') {
       // Ensure that the field only receives numeric data
       this.appendValueInput('SIZE')
@@ -296,7 +325,7 @@ Blockly.propc.sd_read = function() {
   // Identify the block action (fread, fwrite, or fclose)
   const mode = this.getFieldValue('MODE');
 
-  // Handle close stright away
+  // Handle close straight away
   if (mode === 'fclose') {
     return `if(fp) ${mode}(fp);\n`;
   }
@@ -472,6 +501,53 @@ Blockly.propc.sd_file_pointer = function() {
   return code;
 };
 
+
+/**
+ * Close an open file on an sd card reader
+ *
+ * @type {{
+ *    init: Blockly.Blocks.sd_close.init,
+ *    helpUrl: string
+ *  }}
+ */
+Blockly.Blocks['sd_close'] = {
+  helpUrl: Blockly.MSG_SD_HELPURL,
+
+  init: function() {
+    this.appendDummyInput()
+        .appendField('SD file close');
+    this.setPreviousStatement(true, 'Block');
+    this.setNextStatement(true, null);
+    this.setColour(165);
+    this.setTooltip(Blockly.MSG_SD_CLOSE_TOOLTIP);
+  },
+};
+
+Blockly.propc.sd_close = function(block) {
+  // Is there an initialization block in the project
+  let initFound = false;
+  const initSdBlock = Blockly.getMainWorkspace().getBlocksByType(
+      'sd_init', false);
+  if (initSdBlock.length > 0 && initSdBlock[0].isEnabled()) {
+    initFound = true;
+  }
+
+  // Is the sd card reader embedded on the device
+  const project = getProjectInitialState();
+
+  if (project.boardType.name !== 'heb-wx' &&
+      project.boardType.name !== 'activity-board' &&
+      ! initFound) {
+    return SdInitMissingMessage;
+  }
+
+  // Silently mount the embedded sd card device
+  if (!this.disabled && !initFound) {
+    setupSdCard();
+  }
+
+  return 'if(fp) {fclose(fp);\nfp = 0;\n';
+};
 
 /**
  * Mount SD Card

--- a/src/modules/blockly/language/en/messages.js
+++ b/src/modules/blockly/language/en/messages.js
@@ -563,6 +563,7 @@ Blockly.MSG_SD_INIT_TOOLTIP = 'SD card initialize: start the SD card utility.';
 Blockly.MSG_SD_OPEN_TOOLTIP = 'SD card open: open or create the specified file on the SD card';
 Blockly.MSG_SD_READ_TOOLTIP = 'SD card read: read from, write to, or close the current file on the SD card.';
 Blockly.MSG_SD_FILE_POINTER_TOOLTIP = 'SD card file pointer: ';
+Blockly.MSG_SD_CLOSE_TOOLTIP = 'Close SD card file.';
 Blockly.MSG_SERVO_MOVE_TOOLTIP = 'Standard servo: sets the position of a standard servo connected to the I/O pin.';
 Blockly.MSG_SERVO_SPEED_TOOLTIP = 'CR servo speed: sets the speed of a continuous rotation servo connected to the I/O pin.';
 Blockly.MSG_SERVO_SET_RAMP_TOOLTIP = 'CR servo set ramp: sets the amount a servo\'s speed can change each update cycle.';

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -115,3 +115,13 @@ export const TestApplicationName = 'Solocup';
 // TODO: Enumerate the OS version
 // window.navigator.oscpu
 // - Question: is this referring to the navigator.browserspecs in utils.js?
+
+
+/**
+ * Enable messaging in deprecated blocks.
+ * This enabled the block warning triangle message and inserts an
+ * alert message in the emitted code for the deprecated blocks.
+ *
+ * @type {boolean}
+ */
+export const WarnDeprecatedBlocks = false;

--- a/src/modules/toolbox_data.js
+++ b/src/modules/toolbox_data.js
@@ -1125,6 +1125,7 @@ xmlToolbox += '            <block type="heb_erase_all_contacts"></block>';
 xmlToolbox += '        </category>';
 xmlToolbox += '        <category key="category_memory_sdcard" include="heb-wx,">';
 // Solo-473 Add SD_Init block to menu for Flip board type
+// Solo-537 Add SD_close block
 xmlToolbox += '            <block type="sd_init" exclude="activity-board,"></block>';
 xmlToolbox += '            <block type="sd_open"></block>';
 xmlToolbox += '            <block type="sd_read">';
@@ -1135,6 +1136,7 @@ xmlToolbox += '                    </block>';
 xmlToolbox += '                </value>';
 xmlToolbox += '            </block>';
 xmlToolbox += '            <block type="sd_file_pointer"></block>';
+xmlToolbox += '            <block type="sd_close"></block>';
 xmlToolbox += '        </category>';
 xmlToolbox += '    </category>';
 xmlToolbox += '    <category key="category_sensor-input" exclude="s3,heb,heb-wx," colour="140">';
@@ -1271,6 +1273,7 @@ xmlToolbox += '                    </block>';
 xmlToolbox += '                </value>';
 xmlToolbox += '            </block>';
 xmlToolbox += '            <block type="sd_file_pointer"></block>';
+xmlToolbox += '            <block type="sd_close"></block>';
 xmlToolbox += '        </category>';
 xmlToolbox += '    </category>';
 


### PR DESCRIPTION
This request includes two updates, a new sd card reader block and a deprecated block warning system.

**SD File Close Block**
Added a new block to specifically close an open sd card reader file. Prior this this, opening a second file in the project orphaned the file handle from the previous file open.

**Deprecated Block Warning**
Added visual indicators to a block that has been slated for deprecation. These cues include a change in the block color, a triangle warning on the block face and a notice comment embedded in the generated source code. All of these indicators should make it clear that the project should be updated with either a new block or rework the block code to eliminate the deprecated block.
