### PR TITLE
Refactor project loader to address unsupported browsers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ Parallax robots and sensors.
 
 *develop* [![Build Status](https://travis-ci.org/parallaxinc/solo.svg?branch=develop)](https://travis-ci.org/parallaxinc/solo)
 
-## Experimental Options
+### Supported Browsers
+Chrome - v84+  
+Edge - v79+  
+Firefox - v69+  
+Safari - 14.0 +
+
+### Experimental Options
 Several experimental options are available and they can be activated using flags in the URL.  To use one or more of the
 experimental features, add `?experimental=` and whichever feature name(s) below, separated by a pipe `|` character.  For
 example, to turn on experimental blocks and the XML editing features, you would use the URL


### PR DESCRIPTION
This addresses issue #557 
Refactored the uploadHandler() function to catch the error thrown when an older browser attempts to execute the blob.text() method and fails. 

Updated the project README to indicate minimum browsers versions support in this project.

