### PR TITLE
Patch 1.5.7.2 a1

### DIFF
--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -31,7 +31,7 @@ import {
   ApplicationName,
   productBannerHostTrigger,
   TestApplicationName} from './constants';
-import {getURLParameter, getAllUrlParameters} from './utility';
+import {getURLParameter, getAllUrlParameters, logConsoleMessage} from './utility';
 
 /**
  * Display the application name
@@ -88,10 +88,77 @@ function setClickHandlers() {
   });
 }
 
+/**
+ * Approximate the browser brand and version
+ *
+ * @return {(string|string)[]} Returns an array containing the browser brand
+ * name and the browser version.
+ */
+const getBrowserAgent = () => {
+  try {
+    const navUserAgent = navigator.userAgent;
+    let browserName = navigator.appName;
+    let browserVersion = ''+parseFloat(navigator.appVersion);
+    let tempNameOffset;
+    let tempVersionOffset;
+    let tempVersion;
+
+    if ((tempVersionOffset=navUserAgent.indexOf('Opera')) !== -1) {
+      browserName = 'Opera';
+      browserVersion = navUserAgent.substring(tempVersionOffset+6);
+      if ((tempVersionOffset=navUserAgent.indexOf('Version')) !== -1) {
+        browserVersion = navUserAgent.substring(tempVersionOffset+8);
+      }
+    } else if ((tempVersionOffset=navUserAgent.indexOf('MSIE')) !== -1) {
+      browserName = 'Microsoft Internet Explorer';
+      browserVersion = navUserAgent.substring(tempVersionOffset+5);
+    } else if ((tempVersionOffset=navUserAgent.indexOf('Chrome')) !== -1) {
+      browserName = (navigator.brave !== undefined) ? 'Brave' : 'Chrome';
+      browserVersion = navUserAgent.substring(tempVersionOffset+7);
+    } else if ((tempVersionOffset=navUserAgent.indexOf('Safari')) !== -1) {
+      browserName = 'Safari';
+      browserVersion = navUserAgent.substring(tempVersionOffset+7);
+      if ((tempVersionOffset=navUserAgent.indexOf('Version')) !== -1) {
+        browserVersion = navUserAgent.substring(tempVersionOffset+8);
+      }
+    } else if ((tempVersionOffset=navUserAgent.indexOf('Firefox')) !== -1) {
+      browserName = 'Firefox';
+      browserVersion = navUserAgent.substring(tempVersionOffset+8);
+    } else if (
+      (tempNameOffset=navUserAgent.lastIndexOf(' ')+1) <
+        (tempVersionOffset=navUserAgent.lastIndexOf('/')) ) {
+      browserName = navUserAgent.substring(tempNameOffset, tempVersionOffset);
+      browserVersion = navUserAgent.substring(tempVersionOffset+1);
+      if (browserName.toLowerCase() === browserName.toUpperCase()) {
+        browserName = navigator.appName;
+      }
+    }
+
+    // trim version
+    if ((tempVersion=browserVersion.indexOf(';')) !== -1) {
+      browserVersion=browserVersion.substring(0, tempVersion);
+    }
+
+    if ((tempVersion=browserVersion.indexOf(' ')) !== -1) {
+      browserVersion=browserVersion.substring(0, tempVersion);
+    }
+
+    return [browserName, browserVersion];
+  } catch (err) {
+    logConsoleMessage(`Cannot determine browser details. ${err.message}`);
+    return ['None', '0'];
+  }
+};
+
 let appName = ApplicationName;
 if (window.location.hostname === productBannerHostTrigger) {
   appName = TestApplicationName;
 }
+
+// Get the browser brand and version.
+// TODO: Warn user if the browser is not supported
+const [brand, version] = getBrowserAgent();
+console.log(`BrowserName = ${brand}, Version = ${version}`);
 
 showAppName();
 showAppBannerTitle(appName);

--- a/src/modules/prop_term.js
+++ b/src/modules/prop_term.js
@@ -22,6 +22,8 @@
 
 
 // Replacement for the global pTerm variable
+import {logConsoleMessage} from "./utility";
+
 let terminal = null;
 
 /**
@@ -350,44 +352,50 @@ class PropTerm {
      * @description Helper function used to reposition the cursor
      */
   _changeCursor(dx, dy) {
-    if (dy === 1 &&
-        this.buffer.textArray[this.cursor.y].length >= this.cursor.x) {
-      this.buffer.textArray[this.cursor.y] =
-          this.buffer.textArray[this.cursor.y].substr(0, this.cursor.x);
-    }
-
-    this.cursor.x += dx;
-    this.cursor.y += dy;
-
-    if (this.cursor.x > this.size.charactersWide - 1) {
-      this.cursor.x -= this.size.charactersWide;
-      this.cursor.y++;
-      if (!this.buffer.textArray[this.cursor.y]) {
-        this.buffer.textArray[this.cursor.y] = '';
-      }
-    }
-
-    if (this.cursor.x < 0 && this.cursor.y > 0) {
-      this.cursor.y--;
-      this.cursor.x = this.buffer.textArray[this.cursor.y].length;
-      if (this.cursor.x > this.size.charactersWide - 1) {
-        this.cursor.x = this.size.charactersWide - 1;
+    // Trapping possible empty textArray element causing .length to fail
+    try {
+      if (dy === 1 &&
+          this.buffer.textArray[this.cursor.y].length >= this.cursor.x) {
         this.buffer.textArray[this.cursor.y] =
             this.buffer.textArray[this.cursor.y].substr(0, this.cursor.x);
       }
-    } else if (this.cursor.x < 0) {
-      this.cursor.x = 0;
-    }
 
-    if (dy === 1) {
-      this.cursor.x = 0;
-      if (!this.buffer.textArray[this.cursor.y]) {
-        this.buffer.textArray[this.cursor.y] = '';
+      this.cursor.x += dx;
+      this.cursor.y += dy;
+
+      if (this.cursor.x > this.size.charactersWide - 1) {
+        this.cursor.x -= this.size.charactersWide;
+        this.cursor.y++;
+        if (!this.buffer.textArray[this.cursor.y]) {
+          this.buffer.textArray[this.cursor.y] = '';
+        }
       }
-    }
 
-    // since the cursor location has changed, set the scroll to show the cursor.
-    this.cursor.scrolled = 2;
+      if (this.cursor.x < 0 && this.cursor.y > 0) {
+        this.cursor.y--;
+        this.cursor.x = this.buffer.textArray[this.cursor.y].length;
+        if (this.cursor.x > this.size.charactersWide - 1) {
+          this.cursor.x = this.size.charactersWide - 1;
+          this.buffer.textArray[this.cursor.y] =
+              this.buffer.textArray[this.cursor.y].substr(0, this.cursor.x);
+        }
+      } else if (this.cursor.x < 0) {
+        this.cursor.x = 0;
+      }
+
+      if (dy === 1) {
+        this.cursor.x = 0;
+        if (!this.buffer.textArray[this.cursor.y]) {
+          this.buffer.textArray[this.cursor.y] = '';
+        }
+      }
+
+      // since the cursor location has changed, set the scroll
+      // to show the cursor.
+      this.cursor.scrolled = 2;
+    } catch (e) {
+      logConsoleMessage(`_changeCursor: x=${dx}, y=${dy}, ${e.message}`);
+    }
   }
 
   /**


### PR DESCRIPTION
Add code to detect browser name and version. This will be used later to warn a user that the browser they are using is not supported and will likely not work correctly with Solo.

Add code in the prop terminal module to help understand why the move_cursor is occasionally failing on an undefined .length property.