### PR TITLE
Patch 1.5.7.2 a3 sentry

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,8 +21,8 @@ globals:
   tooltip_text: readonly
   utils: readonly
 parserOptions:
-  ecmaVersion: 6
-  sourceType: script
+  ecmaVersion: 8
+  sourceType: module
 rules:
   # This really needs to be an error
   no-prototype-builtins: warn

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,52 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+      "integrity": "sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "websocket-extensions": ">=0.1.4"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.13.14",
     "@types/ace": "0.0.43",
     "acorn": "^7.1.1",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "websocket-extensions": ">=0.1.4"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.13.14",
     "@types/ace": "0.0.43",
     "acorn": "^7.1.1",
     "chai": "^4.2.0",

--- a/src/modules/client_service.js
+++ b/src/modules/client_service.js
@@ -174,7 +174,6 @@ export const clientService = {
    * @param {number} baudRate
    */
   setTerminalBaudRate: function(baudRate) {
-    logConsoleMessage(`Setting terminal baud rate to: ${baudRate}`);
     this.terminalBaudRate = baudRate;
   },
 

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,21 +44,7 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.7.2-a2';
-
-/**
- * Constant string that represents the base, empty project header
- *
- * @type {string}
- *
- * @description Converting the string to a constant because it is referenced
- * in a number of places. The string is sufficiently complex that it could
- * be misspelled without detection.
- *
- * @deprecated This constant is now located in the Project class.
- */
-// eslint-disable-next-line no-unused-vars
-const EMPTY_PROJECT_CODE_HEADER = '<xml xmlns="http://www.w3.org/1999/xhtml">';
+export const APP_VERSION = '1.5.7.2-a3';
 
 /**
  * The name used to store a project that is being loaded from

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -73,7 +73,9 @@ import {openProjectDialog} from './dialogs/open_project';
 import {importProjectDialog} from './dialogs/import_project';
 
 // Start up the sentry monitor before we run
-startSentry();
+startSentry()
+    .then( (resp) => console.log('Sentry has started.'))
+    .catch((err) => console.log('Sentry failed to start'));
 
 /**
  * The call to Blockly.svgResize() requires a reference to the

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -21,7 +21,10 @@
  */
 
 import {startSentry} from './sentry';
-startSentry();
+// Start up the sentry monitor before we run
+startSentry()
+    .then( (resp) => console.log('Sentry has started.'))
+    .catch((err) => console.log('Sentry failed to start'));
 
 import 'bootstrap';
 import * as Cookies from 'js-cookie';

--- a/src/modules/sentry.js
+++ b/src/modules/sentry.js
@@ -28,7 +28,7 @@ import {APP_VERSION, EnableSentry} from './constants';
 /**
  * Initialize the Sentry logger
  */
-function startSentry() {
+const startSentry = async () => {
   /* Error logging */
   if (EnableSentry) {
     Sentry.init({
@@ -42,10 +42,9 @@ function startSentry() {
       // })],
       // tracesSampleRate: 1.0,
     });
-    console.log('Sentry initialized');
   } else {
     console.log(`WARNING: Sentry is disabled.`);
   }
-}
+};
 
 export {startSentry};


### PR DESCRIPTION
Refactor Sentry initialization as an async call to remove it from the mainline code path.  
Remove unused babble-eslint package.  
Update eslint to use version 8 and modules to correct an issue where the IDE was complaining about an unexpected token in async function construct.  
Remove unneeded console logging message.  
