### PR TITLE
Compiler split

### DIFF
--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -26,13 +26,12 @@ import {saveAs} from 'file-saver';
 
 import {getComPort} from './client_connection';
 import {clientService, serviceConnectionTypes} from './client_service';
-import {loadToolbox, prettyCode} from './editor';
+import {loadToolbox} from './editor';
 import {CodeEditor} from './code_editor';
 import {getProjectInitialState} from './project';
-import {getSourceEditor} from './code_editor';
 import {logConsoleMessage, getURLParameter, utils} from './utility';
 import {sanitizeFilename} from './utility';
-
+import {cloudCompile} from './compiler';
 
 /**
  * TODO: Identify the purpose of this variable
@@ -174,147 +173,147 @@ const graph_data = {
   ],
 };
 
+// /**
+//  * Submit a project's source code to the cloud compiler
+//  *
+//  * @param {string} text
+//  * @param {string} action
+//  * @param {function} successHandler Define a callback to be executed upon
+//  *  sucessful compilation
+//  */
+// function cloudCompile(text, action, successHandler) {
+//   const codePropC = getSourceEditor();
+//   const project = getProjectInitialState();
+//   // if PropC is in edit mode, get it from the editor, otherwise
+//   // render it from the blocks.
+//   let propcCode = '';
+//
+//   if (codePropC.getReadOnly()) {
+//     propcCode = prettyCode(
+//         Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
+//   } else {
+//     propcCode = codePropC.getValue();
+//   }
+//
+//   if (propcCode.indexOf('EMPTY_PROJECT') > -1) {
+//     utils.showMessage(Blockly.Msg.DIALOG_EMPTY_PROJECT,
+//         Blockly.Msg.DIALOG_CANNOT_COMPILE_EMPTY_PROJECT);
+//   } else {
+//     $('#compile-dialog-title').text(text);
+//     $('#compile-console').val('Compile... ');
+//     $('#compile-dialog').modal('show');
+//
+//     let terminalNeeded = null;
+//
+//     // TODO: propc editor needs UI for settings for terminal and graphing
+//     if (project.boardType.name !== 'propcfile') {
+//       const consoleBlockList = [
+//         'console_print', 'console_print_variables', 'console_print_multiple',
+//         'console_scan_text', 'console_scan_number', 'console_newline',
+//         'console_clear', 'console_move_to_position', 'oled_font_loader',
+//         'activitybot_display_calibration', 'scribbler_serial_send_text',
+//         'scribbler_serial_send_char', 'scribbler_serial_send_decimal',
+//         'scribbler_serial_send_decimal', 'scribbler_serial_send_ctrl',
+//         'scribbler_serial_cursor_xy',
+//       ];
+//
+//       let consoleBlockCount = 0;
+//       for (let i = 0; i < consoleBlockList.length; i++) {
+//         consoleBlockCount += Blockly.getMainWorkspace()
+//             .getBlocksByType(consoleBlockList[i], false).length;
+//       }
+//
+//       if (consoleBlockCount > 0) {
+//         terminalNeeded = 'term';
+//       } else if (Blockly.getMainWorkspace()
+//           .getBlocksByType('graph_settings', false).length > 0) {
+//         terminalNeeded = 'graph';
+//       }
+//     }
+//
+//     // ------------------------------------------------------------------------
+//     // Contact the container running cloud compiler. If the browser is
+//     // connected via https, direct the compile request to the same port and let
+//     // the load balancer direct the request to the compiler.
+//     // When operating from localhost, expect to find the compiler container on
+//     // localhost as well. There is no override for this at the moment.
+//     // ------------------------------------------------------------------------
+//     let postUrl = `https://${window.location.hostname}:443/single/prop-c/${action}`;
+//     if (window.location.protocol === 'http:') {
+//       postUrl = `http://${window.location.hostname}:5001/single/prop-c/${action}`;
+//     }
+//
+//     // Post the code to the compiler API and await the results
+//     logConsoleMessage(`Requesting compiler service`);
+//     $.ajax({
+//       'method': 'POST',
+//       'url': postUrl,
+//       'data': {'code': propcCode},
+//     }).done(function(data) {
+//       logConsoleMessage(`Receiving compiler service results`);
+//       // The compiler will return one of three payloads:
+//       // Compile-only
+//       // data = {
+//       //     "success": success,
+//       //     "compiler-output": out,
+//       //     "compiler-error": err.decode()
+//       // }
+//       //
+//       // Load to RAM/EEPROM
+//       // data = {
+//       //     "success": success,
+//       //     "compiler-output": out,
+//       //     "compiler-error": err.decode()
+//       //     "binary": base64binary.decode('utf-8')
+//       //     "extension": = extension
+//       // }
+//       //
+//       // General error message
+//       // data = {
+//       //    "success": False,
+//       //    "message": "unknown-action",
+//       //    "data": action
+//       // }
+//       // {success: true, compiler-output: "Succeeded.", compiler-error: ""}
+//
+//       // Check for an error response from the compiler
+//       if (!data || data['compiler-error'] != '') {
+//         // Get message as a string, or blank if undefined
+//         const message = (typeof data['compiler-error'] === 'string') ?
+//             data['compiler-error'] : '';
+//         appendCompileConsoleMessage(
+//             data['compiler-output'] + data['compiler-error'] + message);
+//       } else {
+//         const loadWaitMsg = (action !== 'compile') ? '\nDownload...' : '';
+//         appendCompileConsoleMessage(
+//             data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
+//
+//         if (data.success && successHandler) {
+//           successHandler(data, terminalNeeded);
+//         }
+//         compileConsoleScrollToBottom();
+//       }
+//     }).fail(function(data) {
+//       // Something unexpected has happened while calling the compile service
+//       if (data) {
+//         logConsoleMessage(`Compiler service request failed: ${data.state()}`);
+//
+//         const state = data.state();
+//         let message = 'Unable to compile the project.\n';
+//         if (state === 'rejected') {
+//           message += '\nThe compiler service is temporarily unavailable or';
+//           message += ' unreachable.\nPlease try again in a few moments.';
+//         } else {
+//           message += 'Error "' + data.status + '" has been detected.';
+//         }
+//         appendCompileConsoleMessage(message);
+//       }
+//     });
+//   }
+// }
+
 /**
- * Submit a project's source code to the cloud compiler
- *
- * @param {string} text
- * @param {string} action
- * @param {function} successHandler Define a callback to be executed upon
- *  sucessful compilation
- */
-function cloudCompile(text, action, successHandler) {
-  const codePropC = getSourceEditor();
-  const project = getProjectInitialState();
-  // if PropC is in edit mode, get it from the editor, otherwise
-  // render it from the blocks.
-  let propcCode = '';
-
-  if (codePropC.getReadOnly()) {
-    propcCode = prettyCode(
-        Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
-  } else {
-    propcCode = codePropC.getValue();
-  }
-
-  if (propcCode.indexOf('EMPTY_PROJECT') > -1) {
-    utils.showMessage(Blockly.Msg.DIALOG_EMPTY_PROJECT,
-        Blockly.Msg.DIALOG_CANNOT_COMPILE_EMPTY_PROJECT);
-  } else {
-    $('#compile-dialog-title').text(text);
-    $('#compile-console').val('Compile... ');
-    $('#compile-dialog').modal('show');
-
-    let terminalNeeded = null;
-
-    // TODO: propc editor needs UI for settings for terminal and graphing
-    if (project.boardType.name !== 'propcfile') {
-      const consoleBlockList = [
-        'console_print', 'console_print_variables', 'console_print_multiple',
-        'console_scan_text', 'console_scan_number', 'console_newline',
-        'console_clear', 'console_move_to_position', 'oled_font_loader',
-        'activitybot_display_calibration', 'scribbler_serial_send_text',
-        'scribbler_serial_send_char', 'scribbler_serial_send_decimal',
-        'scribbler_serial_send_decimal', 'scribbler_serial_send_ctrl',
-        'scribbler_serial_cursor_xy',
-      ];
-
-      let consoleBlockCount = 0;
-      for (let i = 0; i < consoleBlockList.length; i++) {
-        consoleBlockCount += Blockly.getMainWorkspace()
-            .getBlocksByType(consoleBlockList[i], false).length;
-      }
-
-      if (consoleBlockCount > 0) {
-        terminalNeeded = 'term';
-      } else if (Blockly.getMainWorkspace()
-          .getBlocksByType('graph_settings', false).length > 0) {
-        terminalNeeded = 'graph';
-      }
-    }
-
-    // ------------------------------------------------------------------------
-    // Contact the container running cloud compiler. If the browser is
-    // connected via https, direct the compile request to the same port and let
-    // the load balancer direct the request to the compiler.
-    // When operating from localhost, expect to find the compiler container on
-    // localhost as well. There is no override for this at the moment.
-    // ------------------------------------------------------------------------
-    let postUrl = `https://${window.location.hostname}:443/single/prop-c/${action}`;
-    if (window.location.protocol === 'http:') {
-      postUrl = `http://${window.location.hostname}:5001/single/prop-c/${action}`;
-    }
-
-    // Post the code to the compiler API and await the results
-    logConsoleMessage(`Requesting compiler service`);
-    $.ajax({
-      'method': 'POST',
-      'url': postUrl,
-      'data': {'code': propcCode},
-    }).done(function(data) {
-      logConsoleMessage(`Receiving compiler service results`);
-      // The compiler will return one of three payloads:
-      // Compile-only
-      // data = {
-      //     "success": success,
-      //     "compiler-output": out,
-      //     "compiler-error": err.decode()
-      // }
-      //
-      // Load to RAM/EEPROM
-      // data = {
-      //     "success": success,
-      //     "compiler-output": out,
-      //     "compiler-error": err.decode()
-      //     "binary": base64binary.decode('utf-8')
-      //     "extension": = extension
-      // }
-      //
-      // General error message
-      // data = {
-      //    "success": False,
-      //    "message": "unknown-action",
-      //    "data": action
-      // }
-      // {success: true, compiler-output: "Succeeded.", compiler-error: ""}
-
-      // Check for an error response from the compiler
-      if (!data || data['compiler-error'] != '') {
-        // Get message as a string, or blank if undefined
-        const message = (typeof data['compiler-error'] === 'string') ?
-            data['compiler-error'] : '';
-        appendCompileConsoleMessage(
-            data['compiler-output'] + data['compiler-error'] + message);
-      } else {
-        const loadWaitMsg = (action !== 'compile') ? '\nDownload...' : '';
-        appendCompileConsoleMessage(
-            data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
-
-        if (data.success && successHandler) {
-          successHandler(data, terminalNeeded);
-        }
-        compileConsoleScrollToBottom();
-      }
-    }).fail(function(data) {
-      // Something unexpected has happened while calling the compile service
-      if (data) {
-        logConsoleMessage(`Compiler service request failed: ${data.state()}`);
-
-        const state = data.state();
-        let message = 'Unable to compile the project.\n';
-        if (state === 'rejected') {
-          message += '\nThe compiler service is temporarily unavailable or';
-          message += ' unreachable.\nPlease try again in a few moments.';
-        } else {
-          message += 'Error "' + data.status + '" has been detected.';
-        }
-        appendCompileConsoleMessage(message);
-      }
-    });
-  }
-}
-
-/**
- * Stub function to the cloudCompile function
+ * This is the onClick event handler for the compile toolbar button
  */
 export function compile() {
   cloudCompile('Compile', 'compile', null);

--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -32,6 +32,7 @@ import {getProjectInitialState} from './project';
 import {logConsoleMessage, getURLParameter, utils} from './utility';
 import {sanitizeFilename} from './utility';
 import {cloudCompile} from './compiler';
+import {serialConsole} from './serial_console';
 
 /**
  * TODO: Identify the purpose of this variable
@@ -173,145 +174,6 @@ const graph_data = {
   ],
 };
 
-// /**
-//  * Submit a project's source code to the cloud compiler
-//  *
-//  * @param {string} text
-//  * @param {string} action
-//  * @param {function} successHandler Define a callback to be executed upon
-//  *  sucessful compilation
-//  */
-// function cloudCompile(text, action, successHandler) {
-//   const codePropC = getSourceEditor();
-//   const project = getProjectInitialState();
-//   // if PropC is in edit mode, get it from the editor, otherwise
-//   // render it from the blocks.
-//   let propcCode = '';
-//
-//   if (codePropC.getReadOnly()) {
-//     propcCode = prettyCode(
-//         Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
-//   } else {
-//     propcCode = codePropC.getValue();
-//   }
-//
-//   if (propcCode.indexOf('EMPTY_PROJECT') > -1) {
-//     utils.showMessage(Blockly.Msg.DIALOG_EMPTY_PROJECT,
-//         Blockly.Msg.DIALOG_CANNOT_COMPILE_EMPTY_PROJECT);
-//   } else {
-//     $('#compile-dialog-title').text(text);
-//     $('#compile-console').val('Compile... ');
-//     $('#compile-dialog').modal('show');
-//
-//     let terminalNeeded = null;
-//
-//     // TODO: propc editor needs UI for settings for terminal and graphing
-//     if (project.boardType.name !== 'propcfile') {
-//       const consoleBlockList = [
-//         'console_print', 'console_print_variables', 'console_print_multiple',
-//         'console_scan_text', 'console_scan_number', 'console_newline',
-//         'console_clear', 'console_move_to_position', 'oled_font_loader',
-//         'activitybot_display_calibration', 'scribbler_serial_send_text',
-//         'scribbler_serial_send_char', 'scribbler_serial_send_decimal',
-//         'scribbler_serial_send_decimal', 'scribbler_serial_send_ctrl',
-//         'scribbler_serial_cursor_xy',
-//       ];
-//
-//       let consoleBlockCount = 0;
-//       for (let i = 0; i < consoleBlockList.length; i++) {
-//         consoleBlockCount += Blockly.getMainWorkspace()
-//             .getBlocksByType(consoleBlockList[i], false).length;
-//       }
-//
-//       if (consoleBlockCount > 0) {
-//         terminalNeeded = 'term';
-//       } else if (Blockly.getMainWorkspace()
-//           .getBlocksByType('graph_settings', false).length > 0) {
-//         terminalNeeded = 'graph';
-//       }
-//     }
-//
-//     // ------------------------------------------------------------------------
-//     // Contact the container running cloud compiler. If the browser is
-//     // connected via https, direct the compile request to the same port and let
-//     // the load balancer direct the request to the compiler.
-//     // When operating from localhost, expect to find the compiler container on
-//     // localhost as well. There is no override for this at the moment.
-//     // ------------------------------------------------------------------------
-//     let postUrl = `https://${window.location.hostname}:443/single/prop-c/${action}`;
-//     if (window.location.protocol === 'http:') {
-//       postUrl = `http://${window.location.hostname}:5001/single/prop-c/${action}`;
-//     }
-//
-//     // Post the code to the compiler API and await the results
-//     logConsoleMessage(`Requesting compiler service`);
-//     $.ajax({
-//       'method': 'POST',
-//       'url': postUrl,
-//       'data': {'code': propcCode},
-//     }).done(function(data) {
-//       logConsoleMessage(`Receiving compiler service results`);
-//       // The compiler will return one of three payloads:
-//       // Compile-only
-//       // data = {
-//       //     "success": success,
-//       //     "compiler-output": out,
-//       //     "compiler-error": err.decode()
-//       // }
-//       //
-//       // Load to RAM/EEPROM
-//       // data = {
-//       //     "success": success,
-//       //     "compiler-output": out,
-//       //     "compiler-error": err.decode()
-//       //     "binary": base64binary.decode('utf-8')
-//       //     "extension": = extension
-//       // }
-//       //
-//       // General error message
-//       // data = {
-//       //    "success": False,
-//       //    "message": "unknown-action",
-//       //    "data": action
-//       // }
-//       // {success: true, compiler-output: "Succeeded.", compiler-error: ""}
-//
-//       // Check for an error response from the compiler
-//       if (!data || data['compiler-error'] != '') {
-//         // Get message as a string, or blank if undefined
-//         const message = (typeof data['compiler-error'] === 'string') ?
-//             data['compiler-error'] : '';
-//         appendCompileConsoleMessage(
-//             data['compiler-output'] + data['compiler-error'] + message);
-//       } else {
-//         const loadWaitMsg = (action !== 'compile') ? '\nDownload...' : '';
-//         appendCompileConsoleMessage(
-//             data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
-//
-//         if (data.success && successHandler) {
-//           successHandler(data, terminalNeeded);
-//         }
-//         compileConsoleScrollToBottom();
-//       }
-//     }).fail(function(data) {
-//       // Something unexpected has happened while calling the compile service
-//       if (data) {
-//         logConsoleMessage(`Compiler service request failed: ${data.state()}`);
-//
-//         const state = data.state();
-//         let message = 'Unable to compile the project.\n';
-//         if (state === 'rejected') {
-//           message += '\nThe compiler service is temporarily unavailable or';
-//           message += ' unreachable.\nPlease try again in a few moments.';
-//         } else {
-//           message += 'Error "' + data.status + '" has been detected.';
-//         }
-//         appendCompileConsoleMessage(message);
-//       }
-//     });
-//   }
-// }
-
 /**
  * This is the onClick event handler for the compile toolbar button
  */
@@ -320,7 +182,8 @@ export function compile() {
 }
 
 /**
- * Begins loading process
+ * The onClick event handler for the Compile to RAM and Compile to EEPROM
+ * UI toolbar buttons of the same names.
  *
  * @param {string} modalMessage message shown at the top of the
  *  compile/load modal.
@@ -335,8 +198,9 @@ export function compile() {
  */
 export function loadInto(modalMessage, compileCommand, loadOption, loadAction) {
   if (clientService.portsAvailable) {
-    cloudCompile(modalMessage, compileCommand, function(data, terminalNeeded) {
+    cloudCompile(modalMessage, compileCommand, function(data) {
       logConsoleMessage(`Processing cloud compiler callback`);
+      const terminalNeeded = isTerminalWindowRequired();
 
       if (clientService.type === serviceConnectionTypes.WS) {
         logConsoleMessage(`(LOAI) Device loaded via websocket`);
@@ -410,9 +274,8 @@ export function loadInto(modalMessage, compileCommand, loadOption, loadAction) {
             'extension': data.extension,
             'comport': getComPort(),
           }, function(loadData) {
-            $('#compile-console')
-                .val($('#compile-console')
-                    .val() + loadData.message);
+            $('#compile-console').val($('#compile-console').val() +
+                loadData.message);
 
             // Scroll automatically to the bottom after new data is added
             document.getElementById('compile-console').scrollTop =
@@ -436,6 +299,46 @@ export function loadInto(modalMessage, compileCommand, loadOption, loadAction) {
         Blockly.Msg.DIALOG_DEVICE_COMM_ERROR_TEXT);
   }
 }
+
+
+/**
+ * Evaluate the project to determine if a terminal or graph window is required
+ * when the project is run on the device
+ *
+ * @return {string}
+ */
+const isTerminalWindowRequired = () => {
+  const project = getProjectInitialState();
+  let terminalNeeded = '';
+
+  // TODO: propc editor needs UI for settings for terminal and graphing
+  if (project.boardType.name !== 'propcfile') {
+    const consoleBlockList = [
+      'console_print', 'console_print_variables', 'console_print_multiple',
+      'console_scan_text', 'console_scan_number', 'console_newline',
+      'console_clear', 'console_move_to_position', 'oled_font_loader',
+      'activitybot_display_calibration', 'scribbler_serial_send_text',
+      'scribbler_serial_send_char', 'scribbler_serial_send_decimal',
+      'scribbler_serial_send_decimal', 'scribbler_serial_send_ctrl',
+      'scribbler_serial_cursor_xy',
+    ];
+
+    let consoleBlockCount = 0;
+    for (let i = 0; i < consoleBlockList.length; i++) {
+      consoleBlockCount += Blockly.getMainWorkspace()
+          .getBlocksByType(consoleBlockList[i], false).length;
+    }
+
+    if (consoleBlockCount > 0) {
+      terminalNeeded = 'term';
+    } else if (Blockly.getMainWorkspace()
+        .getBlocksByType('graph_settings', false).length > 0) {
+      terminalNeeded = 'graph';
+    }
+  }
+  return terminalNeeded;
+};
+
 //
 // /**
 //  * Serial console support
@@ -1262,3 +1165,4 @@ export function compileConsoleScrollToBottom() {
   const compileConsoleObj = document.getElementById('compile-console');
   compileConsoleObj.scrollTop = compileConsoleObj.scrollHeight;
 }
+

--- a/src/modules/compiler.js
+++ b/src/modules/compiler.js
@@ -23,7 +23,6 @@
 import Blockly from 'blockly/core';
 
 import {getSourceEditor} from './code_editor';
-import {getProjectInitialState} from './project';
 import {prettyCode} from './editor';
 import {logConsoleMessage} from './utility';
 import {appendCompileConsoleMessage} from './blocklyc';
@@ -33,14 +32,18 @@ import {showCannotCompileEmptyProject} from './modals';
 /**
  * Submit a project's source code to the cloud compiler
  *
- * @param {string} text
- * @param {string} action
+ * @param {string} text Dialog window title bar text
+ * @param {string} action One of (compile, bin, eeprom).
+ *    compile:  compile the project code and display the results.
+ *    bin:      compile the project code to a binary image and load that image
+ *              to the device RAM
+ *    eeprom:   compile the project code to a binary image and load that image
+ *              to the device EEPROM
  * @param {function} successHandler Define a callback to be executed upon
- *  sucessful compilation
+ *  successful compilation
  */
 export const cloudCompile = (text, action, successHandler) => {
   const codePropC = getSourceEditor();
-  const project = getProjectInitialState();
 
   // if PropC is in edit mode, get it from the editor, otherwise
   // render it from the blocks.
@@ -54,112 +57,84 @@ export const cloudCompile = (text, action, successHandler) => {
     $('#compile-dialog-title').text(text);
     $('#compile-console').val('Compile... ');
     $('#compile-dialog').modal('show');
-
-    let terminalNeeded = null;
-
-    // TODO: propc editor needs UI for settings for terminal and graphing
-    if (project.boardType.name !== 'propcfile') {
-      const consoleBlockList = [
-        'console_print', 'console_print_variables', 'console_print_multiple',
-        'console_scan_text', 'console_scan_number', 'console_newline',
-        'console_clear', 'console_move_to_position', 'oled_font_loader',
-        'activitybot_display_calibration', 'scribbler_serial_send_text',
-        'scribbler_serial_send_char', 'scribbler_serial_send_decimal',
-        'scribbler_serial_send_decimal', 'scribbler_serial_send_ctrl',
-        'scribbler_serial_cursor_xy',
-      ];
-
-      let consoleBlockCount = 0;
-      for (let i = 0; i < consoleBlockList.length; i++) {
-        consoleBlockCount += Blockly.getMainWorkspace()
-            .getBlocksByType(consoleBlockList[i], false).length;
-      }
-
-      if (consoleBlockCount > 0) {
-        terminalNeeded = 'term';
-      } else if (Blockly.getMainWorkspace()
-          .getBlocksByType('graph_settings', false).length > 0) {
-        terminalNeeded = 'graph';
-      }
-    }
-
-    // ------------------------------------------------------------------------
-    // Contact the container running cloud compiler. If the browser is
-    // connected via https, direct the compile request to the same port and let
-    // the load balancer direct the request to the compiler.
-    // When operating from localhost, expect to find the compiler container on
-    // localhost as well. There is no override for this at the moment.
-    // ------------------------------------------------------------------------
-    let postUrl = `https://${window.location.hostname}:443/single/prop-c/${action}`;
-    if (window.location.protocol === 'http:') {
-      postUrl = `http://${window.location.hostname}:5001/single/prop-c/${action}`;
-    }
-
-    // Post the code to the compiler API and await the results
-    logConsoleMessage(`Requesting compiler service`);
-    $.ajax({
-      'method': 'POST',
-      'url': postUrl,
-      'data': {'code': propcCode},
-    }).done(function(data) {
-      logConsoleMessage(`Receiving compiler service results`);
-      // The compiler will return one of three payloads:
-      // Compile-only
-      // data = {
-      //     "success": success,
-      //     "compiler-output": out,
-      //     "compiler-error": err.decode()
-      // }
-      //
-      // Load to RAM/EEPROM
-      // data = {
-      //     "success": success,
-      //     "compiler-output": out,
-      //     "compiler-error": err.decode()
-      //     "binary": base64binary.decode('utf-8')
-      //     "extension": = extension
-      // }
-      //
-      // General error message
-      // data = {
-      //    "success": False,
-      //    "message": "unknown-action",
-      //    "data": action
-      // }
-      // {success: true, compiler-output: "Succeeded.", compiler-error: ""}
-
-      // Check for an error response from the compiler
-      if (!data || data['compiler-error'] !== '') {
-        // Get message as a string, or blank if undefined
-        const message = (typeof data['compiler-error'] === 'string') ?
-            data['compiler-error'] : '';
-        appendCompileConsoleMessage(
-            data['compiler-output'] + data['compiler-error'] + message);
-      } else {
-        const loadWaitMsg = (action !== 'compile') ? '\nDownload...' : '';
-        appendCompileConsoleMessage(
-            data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
-
-        if (data.success && successHandler) {
-          successHandler(data, terminalNeeded);
-        }
-        compileConsoleScrollToBottom();
-      }
-    }).fail(function(data) {
-      // Something unexpected has happened while calling the compile service
-      if (data) {
-        logConsoleMessage(`Compiler service request failed: ${data.state()}`);
-
-        const state = data.state();
-        let message = 'Unable to compile the project.\n';
-        if (state === 'rejected') {
-          message += '\nThe compiler service is temporarily unavailable or';
-          message += ' unreachable.\nPlease try again in a few moments.';
-        } else {
-          message += 'Error "' + data.status + '" has been detected.';
-        }
-        appendCompileConsoleMessage(message);
-      }
-    });
   }
+
+  // ------------------------------------------------------------------------
+  // Contact the container running cloud compiler. If the browser is
+  // connected via https, direct the compile request to the same port and let
+  // the load balancer direct the request to the compiler.
+  // When operating from localhost, expect to find the compiler container on
+  // localhost as well. There is no override for this at the moment.
+  // ------------------------------------------------------------------------
+  let postUrl = `https://${window.location.hostname}:443/single/prop-c/${action}`;
+  if (window.location.protocol === 'http:') {
+    postUrl = `http://${window.location.hostname}:5001/single/prop-c/${action}`;
+  }
+
+  // Post the code to the compiler API and await the results
+  logConsoleMessage(`Requesting compiler service`);
+  $.ajax({
+    'method': 'POST',
+    'url': postUrl,
+    'data': {'code': propcCode},
+  }).done(function(data) {
+    logConsoleMessage(`Receiving compiler service results`);
+    // The compiler will return one of three payloads:
+    // Compile-only
+    // data = {
+    //     "success": success,
+    //     "compiler-output": out,
+    //     "compiler-error": err.decode()
+    // }
+    //
+    // Load to RAM/EEPROM
+    // data = {
+    //     "success": success,
+    //     "compiler-output": out,
+    //     "compiler-error": err.decode()
+    //     "binary": base64binary.decode('utf-8')
+    //     "extension": = extension
+    // }
+    //
+    // General error message
+    // data = {
+    //    "success": False,
+    //    "message": "unknown-action",
+    //    "data": action
+    // }
+    // {success: true, compiler-output: "Succeeded.", compiler-error: ""}
+
+    // Check for an error response from the compiler
+    if (!data || data['compiler-error'] !== '') {
+      // Get message as a string, or blank if undefined
+      const message = (typeof data['compiler-error'] === 'string') ?
+            data['compiler-error'] : '';
+      appendCompileConsoleMessage(
+          data['compiler-output'] + data['compiler-error'] + message);
+    } else {
+      const loadWaitMsg = (action !== 'compile') ? '\nDownload...' : '';
+      appendCompileConsoleMessage(
+          data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
+
+      if (data.success && successHandler) {
+        successHandler(data);
+      }
+      compileConsoleScrollToBottom();
+    }
+  }).fail(function(data) {
+    // Something unexpected has happened while calling the compile service
+    if (data) {
+      logConsoleMessage(`Compiler service request failed: ${data.state()}`);
+
+      const state = data.state();
+      let message = 'Unable to compile the project.\n';
+      if (state === 'rejected') {
+        message += '\nThe compiler service is temporarily unavailable or';
+        message += ' unreachable.\nPlease try again in a few moments.';
+      } else {
+        message += 'Error "' + data.status + '" has been detected.';
+      }
+      appendCompileConsoleMessage(message);
+    }
+  });
 };

--- a/src/modules/compiler.js
+++ b/src/modules/compiler.js
@@ -1,0 +1,165 @@
+/*
+ *   TERMS OF USE: MIT License
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a
+ *   copy of this software and associated documentation files (the "Software"),
+ *   to deal in the Software without restriction, including without limitation
+ *   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *   and/or sell copies of the Software, and to permit persons to whom the
+ *   Software is furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL
+ *   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *   DEALINGS IN THE SOFTWARE.
+ */
+
+import Blockly from 'blockly/core';
+
+import {getSourceEditor} from './code_editor';
+import {getProjectInitialState} from './project';
+import {prettyCode} from './editor';
+import {logConsoleMessage} from './utility';
+import {appendCompileConsoleMessage} from './blocklyc';
+import {compileConsoleScrollToBottom} from './blocklyc';
+import {showCannotCompileEmptyProject} from './modals';
+
+/**
+ * Submit a project's source code to the cloud compiler
+ *
+ * @param {string} text
+ * @param {string} action
+ * @param {function} successHandler Define a callback to be executed upon
+ *  sucessful compilation
+ */
+export const cloudCompile = (text, action, successHandler) => {
+  const codePropC = getSourceEditor();
+  const project = getProjectInitialState();
+
+  // if PropC is in edit mode, get it from the editor, otherwise
+  // render it from the blocks.
+  const propcCode = (codePropC.getReadOnly()) ?
+      prettyCode(Blockly.propc.workspaceToCode(Blockly.mainWorkspace)) :
+      codePropC.getValue();
+
+  if (propcCode.indexOf('EMPTY_PROJECT') > -1) {
+    showCannotCompileEmptyProject();
+  } else {
+    $('#compile-dialog-title').text(text);
+    $('#compile-console').val('Compile... ');
+    $('#compile-dialog').modal('show');
+
+    let terminalNeeded = null;
+
+    // TODO: propc editor needs UI for settings for terminal and graphing
+    if (project.boardType.name !== 'propcfile') {
+      const consoleBlockList = [
+        'console_print', 'console_print_variables', 'console_print_multiple',
+        'console_scan_text', 'console_scan_number', 'console_newline',
+        'console_clear', 'console_move_to_position', 'oled_font_loader',
+        'activitybot_display_calibration', 'scribbler_serial_send_text',
+        'scribbler_serial_send_char', 'scribbler_serial_send_decimal',
+        'scribbler_serial_send_decimal', 'scribbler_serial_send_ctrl',
+        'scribbler_serial_cursor_xy',
+      ];
+
+      let consoleBlockCount = 0;
+      for (let i = 0; i < consoleBlockList.length; i++) {
+        consoleBlockCount += Blockly.getMainWorkspace()
+            .getBlocksByType(consoleBlockList[i], false).length;
+      }
+
+      if (consoleBlockCount > 0) {
+        terminalNeeded = 'term';
+      } else if (Blockly.getMainWorkspace()
+          .getBlocksByType('graph_settings', false).length > 0) {
+        terminalNeeded = 'graph';
+      }
+    }
+
+    // ------------------------------------------------------------------------
+    // Contact the container running cloud compiler. If the browser is
+    // connected via https, direct the compile request to the same port and let
+    // the load balancer direct the request to the compiler.
+    // When operating from localhost, expect to find the compiler container on
+    // localhost as well. There is no override for this at the moment.
+    // ------------------------------------------------------------------------
+    let postUrl = `https://${window.location.hostname}:443/single/prop-c/${action}`;
+    if (window.location.protocol === 'http:') {
+      postUrl = `http://${window.location.hostname}:5001/single/prop-c/${action}`;
+    }
+
+    // Post the code to the compiler API and await the results
+    logConsoleMessage(`Requesting compiler service`);
+    $.ajax({
+      'method': 'POST',
+      'url': postUrl,
+      'data': {'code': propcCode},
+    }).done(function(data) {
+      logConsoleMessage(`Receiving compiler service results`);
+      // The compiler will return one of three payloads:
+      // Compile-only
+      // data = {
+      //     "success": success,
+      //     "compiler-output": out,
+      //     "compiler-error": err.decode()
+      // }
+      //
+      // Load to RAM/EEPROM
+      // data = {
+      //     "success": success,
+      //     "compiler-output": out,
+      //     "compiler-error": err.decode()
+      //     "binary": base64binary.decode('utf-8')
+      //     "extension": = extension
+      // }
+      //
+      // General error message
+      // data = {
+      //    "success": False,
+      //    "message": "unknown-action",
+      //    "data": action
+      // }
+      // {success: true, compiler-output: "Succeeded.", compiler-error: ""}
+
+      // Check for an error response from the compiler
+      if (!data || data['compiler-error'] !== '') {
+        // Get message as a string, or blank if undefined
+        const message = (typeof data['compiler-error'] === 'string') ?
+            data['compiler-error'] : '';
+        appendCompileConsoleMessage(
+            data['compiler-output'] + data['compiler-error'] + message);
+      } else {
+        const loadWaitMsg = (action !== 'compile') ? '\nDownload...' : '';
+        appendCompileConsoleMessage(
+            data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
+
+        if (data.success && successHandler) {
+          successHandler(data, terminalNeeded);
+        }
+        compileConsoleScrollToBottom();
+      }
+    }).fail(function(data) {
+      // Something unexpected has happened while calling the compile service
+      if (data) {
+        logConsoleMessage(`Compiler service request failed: ${data.state()}`);
+
+        const state = data.state();
+        let message = 'Unable to compile the project.\n';
+        if (state === 'rejected') {
+          message += '\nThe compiler service is temporarily unavailable or';
+          message += ' unreachable.\nPlease try again in a few moments.';
+        } else {
+          message += 'Error "' + data.status + '" has been detected.';
+        }
+        appendCompileConsoleMessage(message);
+      }
+    });
+  }
+};

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -1737,6 +1737,8 @@ export function resetToolBoxSizing(resizeDelay, centerBlocks = false) {
     // Set the size of the divs
     for (let i = 0; i < 3; i++) {
       blocklyDiv[i].style.left = '0px';
+      // TODO:  This is getting set to a large value on occasion in
+      //  the content_block div. Search and destroy.
       blocklyDiv[i].style.top = navTop + 'px';
       blocklyDiv[i].style.width = navWidth + 'px';
       blocklyDiv[i].style.height = navHeight + 'px';

--- a/src/modules/modals.js
+++ b/src/modules/modals.js
@@ -25,6 +25,7 @@ import 'bootstrap/js/modal';
 import 'jquery-validation';
 import {displayProjectName} from './editor.js';
 import {getProjectInitialState} from './project';
+import {utils} from './utility';
 
 /**
  *  Validate the required elements of the edit project form
@@ -130,7 +131,7 @@ function setEditOfflineProjectDetailsContinueHandler() {
 function updateProjectDetails() {
   updateProjectNameDescription(
       $('#edit-project-name').val(),
-      $('#edit-project-description').val()
+      $('#edit-project-description').val(),
   );
 }
 
@@ -171,3 +172,11 @@ function setEditOfflineProjectDetailsCancelHandler() {
   });
 }
 
+/**
+ * Display a dialog window that warns of an attempt to compile
+ * an empty project.
+ */
+export const showCannotCompileEmptyProject = () => {
+  utils.showMessage(Blockly.Msg.DIALOG_EMPTY_PROJECT,
+      Blockly.Msg.DIALOG_CANNOT_COMPILE_EMPTY_PROJECT);
+};


### PR DESCRIPTION
* Refactor the cloudCompile() function into a new module.
* Split out the "empty project" alert to the modals module.
* Split out the terminalNeeded code to a separate function. This permits the callback to figure out the correct state of the terminalNeeded inside the callback. This also removes a dependency on the Project module from the cloudCompiler function.