### PR TITLE
More compile module refactoring

### DIFF
--- a/src/modules/modals.js
+++ b/src/modules/modals.js
@@ -180,3 +180,14 @@ export const showCannotCompileEmptyProject = () => {
   utils.showMessage(Blockly.Msg.DIALOG_EMPTY_PROJECT,
       Blockly.Msg.DIALOG_CANNOT_COMPILE_EMPTY_PROJECT);
 };
+
+
+/**
+ *  Display the compiler status modal window
+ * @param {string} titleBar is the text that will appear in the modal title bar
+ */
+export const showCompilerStatusWindow = (titleBar) => {
+  $('#compile-dialog-title').text(titleBar);
+  $('#compile-console').val('Compile... ');
+  $('#compile-dialog').modal('show');
+};


### PR DESCRIPTION
* Functions that call cloudCompiler now must supply source code and open the compile modal window. This removes even mode dependencies the compiler module.
* Inverted logic in loadInto to handle bad data first.
* Moved UI code that inits and opens the compiler status dialog to the modals module.