### PR TITLE
Patch 1.5.8 b4

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -54,3 +54,12 @@ overrides:
     rules: {
       max-len: "off"
     }
+  - files: [
+      "src/modules/**/*.js"
+    ]
+    rules: {
+      max-len: [
+          "warn",
+          code: 100
+      ]
+    }

--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -267,16 +267,40 @@ export const loadInto = async (
 
             await (async () => {
               const port = getComPort();
+
+              // await delay(400);
+              // if (clientService.loaderResetDetect) {
+              //   // eslint-disable-next-line max-len
+              //   logConsoleMessage(`Connection reset detected during load operation`);
+
+              // for (let loop = 0; loop < 5; loop++) {
+              //   logConsoleMessage(`Waiting for connection... (${loop} of 5)`);
+              //   await delay(800);
+              //   if (clientService.activeConnection !== null) {
+              //     if (clientService.activeConnection.readyState === 1) {
+              //       // run it again.
+              //       // eslint-disable-next-line max-len
+              //       logConsoleMessage(`Resubmitting download, ${clientService.activeConnection.bufferedAmount}`);
+              //       await clientService.wsSendLoadProp(
+              //           loadAction, data, terminalNeeded, port);
+              //       // eslint-disable-next-line max-len
+              //       logConsoleMessage(`Sent ${clientService.activeConnection.bufferedAmount} bytes`);
+              //       break;
+              //     }
+              //   }
+              // }
+
               await clientService.wsSendLoadProp(
                   loadAction, data, terminalNeeded, port);
+              logConsoleMessage(`Sent ${clientService.activeConnection.bufferedAmount} bytes`);
 
-              await delay(200);
-              if (clientService.loaderResetDetect) {
+              for (let loop = 0; loop < 5; loop++) {
                 // eslint-disable-next-line max-len
-                logConsoleMessage(`Connection reset detected during load operation`);
-                for (let loop = 0; loop < 5; loop++) {
-                  logConsoleMessage(`Waiting for connection... (${loop} of 5)`);
-                  await delay(800);
+                await delay(800);
+                if (clientService.loaderIsDone) break;
+
+                if (clientService.loaderResetDetect) {
+                  logConsoleMessage(`Waiting for connection... (${loop+1} of 5)`);
                   if (clientService.activeConnection !== null) {
                     if (clientService.activeConnection.readyState === 1) {
                       // run it again.
@@ -286,7 +310,7 @@ export const loadInto = async (
                           loadAction, data, terminalNeeded, port);
                       // eslint-disable-next-line max-len
                       logConsoleMessage(`Sent ${clientService.activeConnection.bufferedAmount} bytes`);
-                      break;
+                      // break;
                     }
                   }
                 }

--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -263,39 +263,14 @@ export const loadInto = async (
             // Send the compile submission via a web socket
             clientService.resultLog = '';
             clientService.loadBinary = false;
-            logConsoleMessage(`Sending Load-Prop message`);
 
             await (async () => {
               const port = getComPort();
 
-              // await delay(400);
-              // if (clientService.loaderResetDetect) {
-              //   // eslint-disable-next-line max-len
-              //   logConsoleMessage(`Connection reset detected during load operation`);
-
-              // for (let loop = 0; loop < 5; loop++) {
-              //   logConsoleMessage(`Waiting for connection... (${loop} of 5)`);
-              //   await delay(800);
-              //   if (clientService.activeConnection !== null) {
-              //     if (clientService.activeConnection.readyState === 1) {
-              //       // run it again.
-              //       // eslint-disable-next-line max-len
-              //       logConsoleMessage(`Resubmitting download, ${clientService.activeConnection.bufferedAmount}`);
-              //       await clientService.wsSendLoadProp(
-              //           loadAction, data, terminalNeeded, port);
-              //       // eslint-disable-next-line max-len
-              //       logConsoleMessage(`Sent ${clientService.activeConnection.bufferedAmount} bytes`);
-              //       break;
-              //     }
-              //   }
-              // }
-
               await clientService.wsSendLoadProp(
                   loadAction, data, terminalNeeded, port);
-              logConsoleMessage(`Sent ${clientService.activeConnection.bufferedAmount} bytes`);
 
               for (let loop = 0; loop < 5; loop++) {
-                // eslint-disable-next-line max-len
                 await delay(800);
                 if (clientService.loaderIsDone) break;
 
@@ -303,58 +278,15 @@ export const loadInto = async (
                   logConsoleMessage(`Waiting for connection... (${loop+1} of 5)`);
                   if (clientService.activeConnection !== null) {
                     if (clientService.activeConnection.readyState === 1) {
-                      // run it again.
-                      // eslint-disable-next-line max-len
-                      logConsoleMessage(`Resubmitting download, ${clientService.activeConnection.bufferedAmount}`);
+                      // Resubmit the project to the Launcher
+                      logConsoleMessage(`Resubmitting download`);
                       await clientService.wsSendLoadProp(
                           loadAction, data, terminalNeeded, port);
-                      // eslint-disable-next-line max-len
-                      logConsoleMessage(`Sent ${clientService.activeConnection.bufferedAmount} bytes`);
-                      // break;
                     }
                   }
                 }
               }
-
-              // if (! clientService.activeConnection ||
-              //     clientService.activeConnection.readyState !== 1) {
-              // eslint-disable-next-line max-len
-              //   logConsoleMessage(`Connection has failed after program load`);
-              //
-              //   for (let loop = 0; loop < 5; loop++) {
-              // eslint-disable-next-line max-len
-              //     logConsoleMessage(`Waiting for connection... (${loop} of 5)`);
-              //     await delay(1000);
-              //     if (clientService.activeConnection !== null) {
-              //       if (clientService.activeConnection.readyState === 1) {
-              //         // run it again.
-              //         logConsoleMessage(`Resubmitting download`);
-              //         await clientService.wsSendLoadProp(
-              //             loadAction, data, terminalNeeded, getComPort());
-              //         break;
-              //       }
-              //     }
-              //   }
-              // }
             })();
-
-            // await clientService.wsSendLoadProp(
-            //     loadAction, data, terminalNeeded, getComPort());
-            // await setTimeout( async () => {
-            //   // eslint-disable-next-line max-len
-            //   logConsoleMessage(`Looking for a pulse:`);
-            //   if (clientService.activeConnection !== null &&
-            //           clientService.activeConnection.readyState === 1) {
-            //     logConsoleMessage(`Connection is active after program load`);
-            //   } else {
-            //     logConsoleMessage(`Looking for a do-over`);
-            //     await setTimeout(async () => {
-            //       // run it again.
-            //       await clientService.wsSendLoadProp(
-            //           loadAction, data, terminalNeeded, getComPort());
-            //     }, 1500);
-            //   }
-            // }, 500);
           } else {
           // Send the compile submission via an HTTP post
             if (clientService.version.isCoded) {
@@ -438,7 +370,6 @@ export const loadInto = async (
   }
 };
 
-
 /**
  * Evaluate the project to determine if a terminal or graph window is required
  * when the project is run on the device
@@ -476,7 +407,6 @@ const isTerminalWindowRequired = () => {
   }
   return terminalNeeded;
 };
-
 
 /**
  * Display information about the serial connection to the device

--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -160,7 +160,7 @@ function establishBPLauncherConnection() {
     let connection;
 
     // Clear the port list
-    clientService.clearPortList();
+    // clientService.clearPortList();
 
     try {
       connection = new WebSocket(clientService.url('', 'ws'));
@@ -370,6 +370,7 @@ function wsCompileMessageProcessor(message) {
 
   if (command === NS_DOWNLOAD_SUCCESSFUL) {
     clientService.loaderResetDetect = false;
+    clientService.loaderIsDone = true;
     appendCompileConsoleMessage('Succeeded.');
   }
 
@@ -378,6 +379,8 @@ function wsCompileMessageProcessor(message) {
       appendCompileConsoleMessage('.');
       break;
     case NE_DOWNLOAD_FAILED:
+      clientService.loaderResetDetect = false;
+      clientService.loaderIsDone = true;
       appendCompileConsoleMessage(
           `Failed!\n\n-------- loader messages --------\n` +
         `${clientService.resultLog}`);

--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -32,7 +32,6 @@ import {logConsoleMessage, utils} from './utility';
 import {propToolbarButtonController} from './toolbar_controller';
 import {getPropTerminal} from './prop_term';
 
-
 /**
  * Enable or disable debug-level console logging
  * @type {boolean}
@@ -54,11 +53,22 @@ const PORT_TIMEOUT = 15000;
  */
 
 /**
+ * Type definition for a Launcher web socket "Hello" message
+ *
  * @typedef WebSocketHelloMessage
  * @type {string} type contains the message text
  * @type {number} baud contains the default baud rate
  * @description This is the format of the object passed into a newly opened
  * WebSocket connection.
+ */
+
+/**
+ * Type definition for a BlocklyProp Client interface
+ *
+ * @typedef {Object} BPClientDataBlock
+ * @property {number} version
+ * @property {string} version_str
+ * @property {string} server
  */
 
 // Status Notice IDs
@@ -147,7 +157,6 @@ export const findClient = function() {
   }
 };
 
-
 /**
  * Checks for and, if found, uses a newer WebSockets-only client
  *
@@ -216,7 +225,6 @@ function establishBPLauncherConnection() {
         // sometimes some weird stuff comes through...
         // type: 'serial-terminal'
         // msg: [String Base64-encoded message]
-        logConsoleMessage(`Received a Serial Terminal message`);
         let messageText;
         try {
           messageText = atob(wsMessage.msg);
@@ -239,8 +247,6 @@ function establishBPLauncherConnection() {
             // is the graph open?
             graphNewData(messageText);
           }
-        } else {
-          logConsoleMessage(`Unable to send stream to the terminal`);
         }
 
         // --- UI Commands coming from the client
@@ -254,7 +260,7 @@ function establishBPLauncherConnection() {
     };
 
     connection.onclose = function(event) {
-      logConsoleMessage(`Closing WS: ${event.code}, ${event.message}`);
+      logConsoleMessage(`Closing socket. Status code: ${event.code}`);
       lostWSConnection();
     };
   }
@@ -407,20 +413,12 @@ function parseCompileMessage(message) {
   return result;
 }
 
-
 /**
  * Lost websocket connection, clean up and restart findClient processing
  */
 function lostWSConnection() {
-  logConsoleMessage(`Lost WS connection`);
   if (clientService.type !== serviceConnectionTypes.HTTP) {
     clientService.loaderResetDetect = true;
-
-    if (clientService.activeConnection) {
-      logConsoleMessage(`Closing socket: ReadyState is:
-     ${clientService.activeConnection.readyState}`);
-    }
-    logConsoleMessage(`Null-ing the active connection`);
     clientService.activeConnection = null;
     clientService.type = serviceConnectionTypes.NONE;
     clientService.available = false;
@@ -504,15 +502,6 @@ function checkClientVersionModal(rawVersion) {
     $('#client-version-modal').modal('show');
   }
 }
-
-/**
- * Type definition for a BlocklyProp Client interface
- *
- * @typedef {Object} BPClientDataBlock
- * @property {number} version
- * @property {string} version_str
- * @property {string} server
- */
 
 /**
  * Establish a connection to the BlocklyProp-Client (BPC) application
@@ -608,7 +597,6 @@ function addComPortDeviceOption(port) {
     $('#comPort').append($('<option>', {text: port}));
   }
 }
-
 
 /**
  * Update the list of serial ports available on the host machine

--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -366,18 +366,19 @@ function wsProcessUiCommand(message) {
  */
 function wsCompileMessageProcessor(message) {
   const [command, text] = parseCompileMessage(message.msg);
-  // logConsoleMessage(`Cmd:${command}: '${text}'`);
-
-  if (command === NS_DOWNLOAD_SUCCESSFUL) {
-    clientService.loaderResetDetect = false;
-    clientService.loaderIsDone = true;
-    appendCompileConsoleMessage('Succeeded.');
-  }
 
   switch (command) {
+    case NS_DOWNLOAD_SUCCESSFUL:
+      clientService.loaderResetDetect = false;
+      clientService.loaderIsDone = true;
+      appendCompileConsoleMessage('Succeeded.');
+      logConsoleMessage(`Project loaded successfully`);
+      return;
+
     case NS_DOWNLOADING:
       appendCompileConsoleMessage('.');
       break;
+
     case NE_DOWNLOAD_FAILED:
       clientService.loaderResetDetect = false;
       clientService.loaderIsDone = true;
@@ -385,8 +386,8 @@ function wsCompileMessageProcessor(message) {
           `Failed!\n\n-------- loader messages --------\n` +
         `${clientService.resultLog}`);
       break;
+
     default:
-      logConsoleMessage(`Processing launcher cmd:message: ${command}:${text}`);
       clientService.resultLog = clientService.resultLog + text + '\n';
   }
   compileConsoleScrollToBottom();

--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -143,7 +143,6 @@ export const findClient = function() {
 
   // If connected to the BP-Client, poll for an updated port list
   if (clientService.type === serviceConnectionTypes.HTTP) {
-    logConsoleMessage('From findClient(): looking for com ports');
     checkForComPorts();
   }
 };
@@ -158,9 +157,6 @@ export const findClient = function() {
 function establishBPLauncherConnection() {
   if (!clientService.available) {
     let connection;
-
-    // Clear the port list
-    // clientService.clearPortList();
 
     try {
       connection = new WebSocket(clientService.url('', 'ws'));

--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -428,9 +428,7 @@ function lostWSConnection() {
     clientService.type = serviceConnectionTypes.NONE;
     clientService.available = false;
   }
-  // Clear ports list
-  // clientService.clearPortList();
-  // setPortListUI();
+
   propToolbarButtonController();
 }
 

--- a/src/modules/client_service.js
+++ b/src/modules/client_service.js
@@ -85,7 +85,6 @@ export const clientService = {
    */
   port: 6009,
 
-
   /**
    * Connection type: "ws", "http", or ''
    * @type {string}
@@ -173,11 +172,28 @@ export const clientService = {
    * Flag to indicate that an attempt to load a program is in progress.
    *
    * @type {boolean}
+   *
    * @description This flag will be set to true if the connection is lost
    * or reset while an active attempt is being made to load a program to the
    * target device.
    */
   loaderResetDetect: false,
+
+  /**
+   * Flag to indicate that the Launcher has reported a complete load cycle,
+   * regardless of success or failure.
+   *
+   * @type {boolean}
+   *
+   * @description This flag is set false at the beginning of a load to device
+   * cycle. If the cycle is interrupted by a web socket disconnect, this flag
+   * ensures that the application will retry the load process until it receives
+   * a message from the Launcher that the load succeeded or failed. Either of
+   * these states will reset the flag. The code that manages loader retries
+   * relies on this flag and the loaderResetDetect flag to determine if a reload
+   * attempt is necessary.
+   */
+  loaderIsDone: false,
 
   /**
    * Setter for terminal baud rate
@@ -346,6 +362,7 @@ export const clientService = {
       }
 
       this.loaderResetDetect = false;
+      this.loaderIsDone = false;
       this.activeConnection.send(payload);
 
       if (debug) {

--- a/src/modules/client_service.js
+++ b/src/modules/client_service.js
@@ -313,7 +313,6 @@ export const clientService = {
     }
   },
 
-
   /**
    * Send a load-prop message to the BP Launcher
    *
@@ -339,10 +338,7 @@ export const clientService = {
       logConsoleMessage(`(wsSLP) Action: ${programToSend.action}`);
       logConsoleMessage(`(wsSLP) Debug: ${programToSend.debug}`);
       logConsoleMessage(`(wsSLP) ComPort: ${programToSend.portPath}`);
-
-      // eslint-disable-next-line max-len
-      logConsoleMessage(
-          `(wsSLP) Web socket state is: ` +
+      logConsoleMessage(`(wsSLP) Web socket state is: ` +
           `${clientService.activeConnection.readyState}`);
     }
 
@@ -366,8 +362,8 @@ export const clientService = {
       this.activeConnection.send(payload);
 
       if (debug) {
-        // eslint-disable-next-line max-len
-        logConsoleMessage(`WS buffer is ${this.activeConnection.bufferedAmount} bytes after transmit`);
+        logConsoleMessage(`WS buffer is ${this.activeConnection.bufferedAmount} ` +
+        `bytes after transmit`);
       }
     } else {
       logConsoleMessage(

--- a/src/modules/compiler.js
+++ b/src/modules/compiler.js
@@ -22,6 +22,8 @@
 
 import {logConsoleMessage} from './utility';
 import {appendCompileConsoleMessage} from './blocklyc';
+import {APP_STAGE} from './constants';
+
 
 // noinspection HttpUrlsUsage
 /**
@@ -52,8 +54,13 @@ export const cloudCompile = async (action, sourceCode) => {
     postUrl = `http://${window.location.hostname}:5001/single/prop-c/${action}`;
   }
 
+  if (APP_STAGE === 'TEST') {
+    // noinspection HttpUrlsUsage
+    postUrl = `https://solo.parallax.com/single/prop-c/${action}`;
+  }
+
   // Post the code to the compiler API and await the results
-  logConsoleMessage(`Requesting compiler service`);
+  logConsoleMessage(`Requesting compiler service from ${postUrl}`);
 
   // Try the compile operation
   try {

--- a/src/modules/compiler.js
+++ b/src/modules/compiler.js
@@ -24,7 +24,6 @@ import {logConsoleMessage} from './utility';
 import {appendCompileConsoleMessage} from './blocklyc';
 import {APP_STAGE} from './constants';
 
-
 // noinspection HttpUrlsUsage
 /**
  * Submit a project's source code to the cloud compiler
@@ -65,7 +64,6 @@ export const cloudCompile = async (action, sourceCode) => {
   // Try the compile operation
   try {
     const result = await postToCompiler(postUrl, sourceCode);
-    logConsoleMessage(`Compile successful. ${result.success}`);
     if (result.success) {
       appendCompileConsoleMessage(
           `${result['compiler-output']}
@@ -91,76 +89,7 @@ export const cloudCompile = async (action, sourceCode) => {
     logConsoleMessage(`(PTC) Error while compiling`);
     logConsoleMessage(`(PTC) Message: ${e.message}`);
   }
-
-  // hideCompilerStatusWindow();
-
-  // $.ajax({
-  //   'method': 'POST',
-  //   'url': postUrl,
-  //   'data': {'code': sourceCode},
-  // }).done(function(data) {
-  //   logConsoleMessage(`Receiving compiler service results`);
-  //   // The compiler will return one of three payloads:
-  //   // Compile-only
-  //   // data = {
-  //   //     "success": success,
-  //   //     "compiler-output": out,
-  //   //     "compiler-error": err.decode()
-  //   // }
-  //   //
-  //   // Load to RAM/EEPROM
-  //   // data = {
-  //   //     "success": success,
-  //   //     "compiler-output": out,
-  //   //     "compiler-error": err.decode()
-  //   //     "binary": base64binary.decode('utf-8')
-  //   //     "extension": = extension
-  //   // }
-  //   //
-  //   // General error message
-  //   // data = {
-  //   //    "success": False,
-  //   //    "message": "unknown-action",
-  //   //    "data": action
-  //   // }
-  //   // {success: true, compiler-output: "Succeeded.", compiler-error: ""}
-  //
-  //   // Check for an error response from the compiler
-  //   if (!data || data['compiler-error'] !== '') {
-  //     // Get message as a string, or blank if undefined
-  //     const message = (typeof data['compiler-error'] === 'string') ?
-  //           data['compiler-error'] : '';
-  //     appendCompileConsoleMessage(
-  //         data['compiler-output'] + data['compiler-error'] + message);
-  //   } else {
-  //     const loadWaitMsg = (action !== 'compile') ? '\nDownload...' : '';
-  //     appendCompileConsoleMessage(
-  //         data['compiler-output'] + data['compiler-error'] + loadWaitMsg);
-  //
-  //     // Execute the callback if one has been provided.
-  //     if (data.success && successHandler) {
-  //       successHandler(data);
-  //     }
-  //     compileConsoleScrollToBottom();
-  //   }
-  // }).fail(function(data) {
-  //   // Something unexpected has happened while calling the compile service
-  //   if (data) {
-  //     logConsoleMessage(`Compiler service request failed: ${data.state()}`);
-  //
-  //     const state = data.state();
-  //     let message = 'Unable to compile the project.\n';
-  //     if (state === 'rejected') {
-  //       message += '\nThe compiler service is temporarily unavailable or';
-  //       message += ' unreachable.\nPlease try again in a few moments.';
-  //     } else {
-  //       message += 'Error "' + data.status + '" has been detected.';
-  //     }
-  //     appendCompileConsoleMessage(message);
-  //   }
-  // });
 };
-
 
 /**
  * Send source code to the compiler
@@ -171,8 +100,6 @@ export const cloudCompile = async (action, sourceCode) => {
  * @return {Promise<any>}
  */
 const postToCompiler = async function(url, sourceCode = '') {
-  logConsoleMessage(`Submitting request to the compiler`);
-
   // Fetch options
   const fetchInit = {
     method: 'POST',
@@ -189,7 +116,6 @@ const postToCompiler = async function(url, sourceCode = '') {
 
   try {
     const res = await fetch(url, fetchInit);
-    logConsoleMessage(`Returning compiled project`);
     return await res.json();
   } catch (err) {
     logConsoleMessage(`Compiler error: ${err.message}`);

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,7 +44,15 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.7.2-b1';
+export const APP_VERSION = '1.5.8-b4';
+
+/**
+ * Set this to target deployment environment.
+ *
+ * This is a temporary use while environment variables are implemented.
+ * @type {string}
+ */
+export const APP_STAGE = 'TEST';
 
 /**
  * The name used to store a project that is being loaded from

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -32,7 +32,6 @@ const path = require('path');
  */
 const targetPath = '../dist';
 
-
 module.exports = merge(baseConfig, {
   devServer: {
     port: 3000

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -28,6 +28,13 @@ const baseConfig = require('./base.config');
 // const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TerserPlugin = require("terser-webpack-plugin");
 
+
+/**
+ * The relative path to the distribution directory
+ * @type {string}
+ */
+const targetPath = '../dist';
+
 module.exports = merge(baseConfig, {
   // Use env.<YOUR VARIABLE> here:
   // console.log('NODE_ENV: ', env.NODE_ENV); // 'local'
@@ -36,7 +43,7 @@ module.exports = merge(baseConfig, {
   mode: 'production',
   devtool: 'source-map',
   output: {
-    path: path.resolve(__dirname, '../dist'),
+    path: path.resolve(__dirname, targetPath),
     filename: '[name].bundle.[chunkhash].js',
 //        chunkFilename: '[id].bundle.js',
 //        pathinfo: true,
@@ -61,33 +68,37 @@ module.exports = merge(baseConfig, {
       patterns: [
         {
           from: './index.html',
-          to: path.resolve(__dirname, '../dist')
+          to: path.resolve(__dirname, targetPath)
         },
         {
           from: './blocklyc.html',
-          to: path.resolve(__dirname, '../dist')
+          to: path.resolve(__dirname, targetPath)
         },
         {
           // Copy over media resources from the Blockly package
           from: path.resolve(__dirname, '../node_modules/blockly/media'),
-          to: path.resolve(__dirname, '../dist/media')
+          to: path.resolve(__dirname, `${targetPath}/media`)
+        },
+        {
+          from: './src/images',
+          to: path.resolve(__dirname, `${targetPath}/images`)
         },
         {
           // Copy over style sheets
           from: './src/site.css',
-          to: path.resolve(__dirname, '../dist')
+          to: path.resolve(__dirname, targetPath)
         },
         {
           from: './src/style.css',
-          to: path.resolve(__dirname, '../dist')
+          to: path.resolve(__dirname, targetPath)
         },
         {
           from: './src/style-clientdownload.css',
-          to: path.resolve(__dirname, '../dist')
+          to: path.resolve(__dirname, targetPath)
         },
         {
           from: './src/style-editor.css',
-          to: path.resolve(__dirname, '../dist')
+          to: path.resolve(__dirname, targetPath)
         },
       ]
     })


### PR DESCRIPTION
Complete refactoring of the code that sends compiled project payload to the Launcher. This update allows Solo to detect that there has been a web socket connection failure (see #394,  #514) and wait for the connection to be re-established before retrying the load operation. This effectively overcomes the issue in Chrome that is causing the disconnect.

Changed the port list behavior such that Solo will no longer invalidate the current port list if the web socket connection is lost. Instead, it will retain the list it last received from the Launcher until it receives an updated list from the Launcher. This improves the stability of the UI when the web socket connection is lost.

Removed a number of console messages that were no longer useful. 