### PR TITLE
Remove all references to the deprecated BlocklyProp Client.

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -738,9 +738,6 @@
                             <!-- <li><a href="#" class="show-os-lnx"><span class="keyed-lang-string" data-key="os_name_lnx"></span></a></li> -->
                         </ul>
                     </div>
-                    <button id="older-clients" class="btn btn-sm btn-primary"
-                            style="display:inline-block; margin-left:20px;">
-                        Show BlocklyProp-Client (older) downloads</button>
                 </div>
             </div>
         </div>
@@ -811,15 +808,6 @@
                                       data-key="client_download_launcher_macos_high_sierra_installer"></span></a>
                         </div>
 
-                        <!-- MacOS Client download link -->
-                        <div class="client MacOS bpc-old hidden">
-                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                                data-src="images/os-icons/mac_os.png" alt="Mac OS icon" />
-                            <a href="#" class="client-mac-link">
-                                <span class="keyed-lang-string"
-                                    data-key="clientdownload_client_macos_installer"></span></a>
-                        </div>
-
                         <!-- Windows clients -->
                         <div class="client-instructions Windows">
                             <h4 class="keyed-lang-string" data-key="clientdownload_download_installer">&nbsp;</h4>
@@ -843,47 +831,6 @@
                             <a href="#" class="launcher-win64zip-link">
                                 <span class="keyed-lang-string"
                                       data-key="clientdownload_launcher_windows64zip_installer"></span>
-                            </a>
-                        </div>
-
-                        <!-- Windows x32 client -->
-                        <div class="client Windows bpc-old hidden">
-                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                                data-src="images/os-icons/windows.png" alt="Windows OS icon" />
-                            <a href="#" class="client-win32-link">
-                                <span class="keyed-lang-string"
-                                    data-key="clientdownload_client_windows32_installer"></span>
-                            </a>
-                        </div>
-
-                        <!-- Windows x32 client zip file -->
-                        <div class="client Windows bpc-old hidden">
-                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                                 data-src="images/os-icons/windows.png" alt="Windows OS icon" />
-                            <a href="#" class="client-win32zip-link">
-                                <span class="keyed-lang-string"
-                                      data-key="clientdownload_client_windows32zip_installer"></span>
-                            </a>
-                        </div>
-
-                        <!-- Windows x64 client -->
-                        <div class="client Windows bpc-old hidden">
-                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                                data-src="images/os-icons/windows.png" alt="Windows OS icon" />
-                            <a href="#" class="client-win64-link">
-                                <span class="keyed-lang-string"
-                                    data-key="clientdownload_client_windows64_installer"></span>
-                            </a>
-                        </div>
-
-
-                        <!-- Windows x64 client -->
-                        <div class="client Windows bpc-old hidden">
-                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                                 data-src="images/os-icons/windows.png" alt="Windows OS icon" />
-                            <a href="#" class="client-win64zip-link">
-                                <span class="keyed-lang-string"
-                                      data-key="clientdownload_client_windows64zip_installer"></span>
                             </a>
                         </div>
 
@@ -929,8 +876,6 @@
                             </li>
                         </ul>
                     </div>
-                    <button id="show-older-clients" style="display: inline;"
-                            class="btn btn-sm btn-primary">Show BlocklyProp-Client (older) downloads</button>
                 </div>
 
                 <div class="modal-footer">

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -230,12 +230,6 @@ function initEventHandlers() {
     resetToolBoxSizing(100);
   });
 
-  // View older BP Client installations button onClick handler
-  $('#older-clients').on('click', function() {
-    $('.bpc-old').removeClass('hidden');
-    // $(this).addClass('hidden');
-  });
-
   // ----------------------------------------------------------------------- //
   // Left side toolbar event handlers                                        //
   // ----------------------------------------------------------------------- //
@@ -357,27 +351,11 @@ function initEventHandlers() {
   $('.show-os-chr').on('click', () => showOS('ChromeOS'));
   $('.show-os-lnx').on('click', () => showOS('Linux'));
 
-  // Hide these elements of the Open Project File modal when it
-  // receives focus
-  // $('#selectfile').focus(function() {
-  //   logConsoleMessage(`Resetting select file validation messages`);
-  //   $('#selectfile-verify-notvalid').css('display', 'none');
-  //   $('#selectfile-verify-valid').css('display', 'none');
-  //   $('#selectfile-verify-boardtype').css('display', 'none');
-  // });
-
   // Serial port drop down onClick event handler
   $('#comPort').on('change', (event) => {
     logConsoleMessage(`Selecting port: ${event.target.value}`);
     clientService.setSelectedPort(event.target.value);
     propToolbarButtonController();
-  });
-
-  // Click event handler for the older BP Clients dialog
-  $('#show-older-clients').on('click', function() {
-    $('.bpc-old').removeClass('hidden');
-    // eslint-disable-next-line no-invalid-this
-    $(this).addClass('hidden');
   });
 }
 


### PR DESCRIPTION
The BlocklyProp Client has been deprecated for over a year. The updates to Solo v1.5.8 are breaking changes for the Client. This update removes the UI elements that allow the user to download the BlocklyProp Client. Subsequent updates will begin removing the Client related code within the app.