### PR TITLE
Rely on selected port to guide Load To button state.

### DIFF
--- a/src/modules/toolbar_controller.js
+++ b/src/modules/toolbar_controller.js
@@ -75,7 +75,7 @@ export function propToolbarButtonController() {
        clientService.type === serviceConnectionTypes.WS )) {
     if (clientService.portsAvailable &&
         clientService.portList.length > 0 &&
-        clientService.portList[0].length > 0) {
+        clientService.getSelectedPort().length > 0) {
       if (isS3boardType) {
         setS3UIButtonGroup();
       } else {


### PR DESCRIPTION
Addresses #572.

The toolbar controller has been relying on the first element of the port list to be non-blank to indicate a selected port. This update changes that to rely on the client_connection object as the single source of truth for connection state and queries the object for the current selected port.