### PR TITLE
Toolbar ghosting with valid connection - part 2

### DIFF
--- a/src/modules/blocklyc.js
+++ b/src/modules/blocklyc.js
@@ -28,7 +28,7 @@ import {getComPort} from './client_connection';
 import {clientService, serviceConnectionTypes} from './client_service';
 import {loadToolbox} from './editor';
 import {CodeEditor, getSourceEditor} from './code_editor';
-import {getProjectInitialState} from './project';
+import {getProjectInitialState, Project} from './project';
 import {cloudCompile} from './compiler';
 import {serialConsole} from './serial_console';
 import {showCannotCompileEmptyProject, showCompilerStatusWindow} from './modals';
@@ -1089,3 +1089,23 @@ export function compileConsoleScrollToBottom() {
   compileConsoleObj.scrollTop = compileConsoleObj.scrollHeight;
 }
 
+/**
+ * Are there any blocks in the Blockly workspace
+ * @return {boolean}
+ */
+export const hasCode = () => {
+  let result = false;
+  if (Blockly) {
+    if (Blockly.Xml) {
+      if (Blockly.mainWorkspace) {
+        const xml = Blockly.Xml.workspaceToDom(Blockly.mainWorkspace);
+        const text = Blockly.Xml.domToText(xml);
+        const emptyHeader = Project.getTerminatedEmptyProjectCodeHeader();
+        if (text !== emptyHeader) {
+          result = true;
+        }
+      }
+    }
+  }
+  return result;
+};

--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -280,6 +280,9 @@ function establishBPLauncherConnection() {
  *  wsMessage.ports is a array of available ports
  */
 function wsProcessPortListMessage(message) {
+  if (debug) {
+    logConsoleMessage(`Processing port list message: ${message}`);
+  }
   if (clientService.getPortLastUpdate() === 0) {
     logConsoleMessage(`Port list received`);
   }
@@ -289,7 +292,7 @@ function wsProcessPortListMessage(message) {
       clientService.addPort(port);
     });
   }
-  setPortListUI();
+  setPortListUI(null);
   clientService.portListReceiveCountUp = 0;
 }
 
@@ -428,12 +431,15 @@ function lostWSConnection() {
 }
 
 /**
- * Set communication port list. Leave data unspecified when searching
+ * Set comms port list. Leave data unspecified when searching
  *
  * @param {Array | null} data
  */
 const setPortListUI = function(data = null) {
   if (! data) {
+    if (debug) {
+      console.log(`Using internal port list`);
+    }
     data = clientService.portList;
   }
 
@@ -451,6 +457,9 @@ const setPortListUI = function(data = null) {
   if (typeof (data) === 'object' && data.length > 0) {
     let blankPort = false;
     data.forEach(function(port) {
+      if (debug) {
+        console.log(`COM Port: ${port}`);
+      }
       if (port.length === 0) {
         blankPort = true;
       }
@@ -575,6 +584,7 @@ function selectComPort(comPort) {
   // A valid com port has been selected
   if (comPort !== null) {
     uiComPort.val(comPort);
+    clientService.setSelectedPort(comPort);
     return;
   }
 

--- a/src/modules/client_service.js
+++ b/src/modules/client_service.js
@@ -230,19 +230,24 @@ export const clientService = {
   },
 
   /**
-   * Setter for the selectedPort property
+   * Set the selectedPort property ony if the new setting is different than
+   * the current setting. Any change is reported to the Launcher as the new
+   * preferred com port.
+   *
    * @param {string} portName
    */
   setSelectedPort: function(portName) {
     // Sentry Solo-6T
     if (this.activeConnection) {
-      logConsoleMessage(`Setting preferred port to: ${portName}`);
-      this.selectedPort_ = portName;
-      // Request a port list from the server
-      this.activeConnection.send(JSON.stringify({
-        type: 'pref-port',
-        portPath: portName,
-      }));
+      if (portName !== this.getSelectedPort()) {
+        logConsoleMessage(`Setting preferred port to: ${portName}`);
+        this.selectedPort_ = portName;
+        // Request a port list from the server
+        this.activeConnection.send(JSON.stringify({
+          type: 'pref-port',
+          portPath: portName,
+        }));
+      }
     }
   },
 

--- a/src/modules/toolbar_controller.js
+++ b/src/modules/toolbar_controller.js
@@ -20,9 +20,8 @@
  *   DEALINGS IN THE SOFTWARE.
  */
 
-import Blockly from 'blockly/core';
-
-import {Project, getProjectInitialState} from './project.js';
+import {hasCode} from './blocklyc';
+import {getProjectInitialState} from './project.js';
 import {clientService, serviceConnectionTypes} from './client_service';
 
 
@@ -355,25 +354,4 @@ export function initToolbarIcons() {
     // `Init icons: ${key}, ${value.dataset.icon}, icon:${value.dataset.icon}`);
     $(value).html(bpIcons[value.dataset.icon]);
   });
-}
-
-/**
- * Are there any blocks in the Blockly workspace
- * @return {boolean}
- */
-function hasCode() {
-  let result = false;
-  if (Blockly) {
-    if (Blockly.Xml) {
-      if (Blockly.mainWorkspace) {
-        const xml = Blockly.Xml.workspaceToDom(Blockly.mainWorkspace);
-        const text = Blockly.Xml.domToText(xml);
-        const emptyHeader = Project.getTerminatedEmptyProjectCodeHeader();
-        if (text !== emptyHeader) {
-          result = true;
-        }
-      }
-    }
-  }
-  return result;
 }


### PR DESCRIPTION
This update further addresses issue #572.  
Notify clientService when a com port is selected so it can notify the Launcher of the selection.
The setSelectedPort method now sends an update to the Launcher only when the selected com port has changed.
Migrate the hasCode function to the blockly module.