### PR TITLE
Remove noisy console message

### DIFF
--- a/src/modules/blockly/generators/propc/communicate.js
+++ b/src/modules/blockly/generators/propc/communicate.js
@@ -1380,7 +1380,6 @@ Blockly.Blocks.serial_send_text = {
   onchange: function(event) {
     // Filter events for only 'serial_open' blocks or deletion events or
     // changes to the serial_print_multiple block
-    console.log('serial_send_text:Change');
     if (event &&
         (event.type === Blockly.Events.BLOCK_CREATE ||
          event.type === Blockly.Events.BLOCK_DELETE ||


### PR DESCRIPTION
Located a console message in the serial_send block definition and removed it.