### PR TITLE
Correct getHtmlText not defined

### DIFF
--- a/src/modules/blockly/language/en/page_text_labels.js
+++ b/src/modules/blockly/language/en/page_text_labels.js
@@ -161,10 +161,17 @@ export const initHtmlLabels = async (value) => {
   }
 };
 
+/**
+ * Find a message string
+ *
+ * @param {string} key
+ * @return {string}
+ */
 export const getHtmlText = (key) => {
   try {
     return PageTextLabels[key];
   } catch (e) {
     logConsoleMessage(`Unable to find ${key} in text labels`);
+    return '';
   }
 };


### PR DESCRIPTION
Addresses issue #591. Update getHtmlText to always return a string, even when the key is not found.