### PR TITLE
Correct TypeError Cannot read property 'send' of null

### DIFF
--- a/src/modules/client_service.js
+++ b/src/modules/client_service.js
@@ -539,7 +539,7 @@ export function initTerminal() {
       document.getElementById('serial_console'),
 
       function(characterToSend) {
-        if (clientService.type === serviceConnectionTypes.WS) {
+        if (clientService.type === serviceConnectionTypes.WS && clientService.activeConnection) {
           const msgToSend = {
             type: 'serial-terminal',
             outTo: 'terminal',

--- a/src/modules/prop_term.js
+++ b/src/modules/prop_term.js
@@ -44,7 +44,7 @@ class PropTerm {
   /**
    * @param {HTMLElement} terminalElement HTML element to populate the
    *    terminal into.
-   * @param {object} outputCallback function to call and send characters
+   * @param {function} outputCallback function to call and send characters
    *    typed into the terminal.
    * @param {TerminalOptions} options for configuring the terminal.
    */


### PR DESCRIPTION
Addresses issue #596

This corrects an error that assumed that the clientService.activeConnnection property was not null, as is the case when the connection is closed. 

This also contains a refactor of the findClient method that clearly separates the watchdog timing code from the code that is actually looking for a Launcher connection.