### PR TITLE
Upgrade Blockly core from 2.20190722.1 to 3.20191014.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -841,9 +841,9 @@
       "dev": true
     },
     "abab": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -880,9 +880,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
         }
       }
     },
@@ -1411,11 +1411,11 @@
       }
     },
     "blockly": {
-      "version": "2.20190722.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-2.20190722.1.tgz",
-      "integrity": "sha512-cz67kCWuk1d0T8jw3Y//32o4HNuig7bVYoB3OTEFNNY+0IoQrSsMFI0Agm/uV/LdVCFpORrnm49OBl46+npoYg==",
+      "version": "3.20200924.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200924.4.tgz",
+      "integrity": "sha512-KDPVLJSguxwKXL6GVdVaYRINoxtojTsQ4lOhuWS9LkzyMhmQVZKMgFzlQum5rE5+hlhzj1BqqUQHe8JbfvL+dQ==",
       "requires": {
-        "jsdom": "^15.1.1"
+        "jsdom": "^15.2.1"
       }
     },
     "bluebird": {
@@ -8605,19 +8605,19 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.19"
       }
     },
     "request-promise-native": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
       "requires": {
-        "request-promise-core": "1.1.3",
+        "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@sentry/browser": "^6.3.6",
     "@sentry/tracing": "^6.3.6",
     "ace-builds": "^1.4.8",
-    "blockly": "^2.20190722.1",
+    "blockly": "^3.20191014.4",
     "bootbox": "^5.4.0",
     "bootstrap": "^3.4.1",
     "canvas": "^2.5.0",

--- a/src/modules/blockly/generators/propc.js
+++ b/src/modules/blockly/generators/propc.js
@@ -713,17 +713,17 @@ Blockly.Input.prototype.getRange = function() {
  * 2019 Q4 - delete after replacing with a core containing these fixes
  * @package
  */
-Blockly.FieldVariable.prototype.initModel = function() {
-  if (this.variable_) {
-    return; // Initialization already happened.
-  }
-  const variable = Blockly.Variables.getOrCreateVariablePackage(
-      this.getSourceBlock().workspace, null,
-      this.defaultVariableName, this.defaultType_);
-
-  // Don't call setValue because we don't want to cause a rerender.
-  this.doValueUpdate_(variable.getId());
-};
+// Blockly.FieldVariable.prototype.initModel = function() {
+//   if (this.variable_) {
+//     return; // Initialization already happened.
+//   }
+//   const variable = Blockly.Variables.getOrCreateVariablePackage(
+//       this.getSourceBlock().workspace, null,
+//       this.defaultVariableName, this.defaultType_);
+//
+//   // Don't call setValue because we don't want to cause a rerender.
+//   this.doValueUpdate_(variable.getId());
+// };
 
 /**
  * Update the source block when the mutator's blocks are changed.
@@ -734,108 +734,111 @@ Blockly.FieldVariable.prototype.initModel = function() {
  * @param {!Blockly.Events.Abstract} e Custom data for event.
  * @private
  */
-Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
-  if (e.type == Blockly.Events.UI ||
-        (e.type == Blockly.Events.CHANGE && e.element == 'disabled')) {
-    return;
-  }
-
-  if (!this.workspace_.isDragging()) {
-    const blocks = this.workspace_.getTopBlocks(false);
-    const MARGIN = 20;
-    for (let b = 0, block; (block = blocks[b]); b++) {
-      const blockXY = block.getRelativeToSurfaceXY();
-      const blockHW = block.getHeightWidth();
-      if (blockXY.y + blockHW.height < MARGIN) {
-        // Bump any block that's above the top back inside.
-        block.moveBy(0, MARGIN - blockHW.height - blockXY.y);
-      }
-    }
-  }
-
-  // When the mutator's workspace changes, update the source block.
-  if (this.rootBlock_.workspace == this.workspace_) {
-    Blockly.Events.setGroup(true);
-    const block = this.block_;
-    const oldMutationDom = block.mutationToDom();
-    const oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
-    // Allow the source block to rebuild itself.
-    block.compose(this.rootBlock_);
-    block.render();
-    const newMutationDom = block.mutationToDom();
-    const newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
-    if (oldMutation != newMutation) {
-      Blockly.Events.fire(new Blockly.Events.BlockChange(
-          block, 'mutation', null, oldMutation, newMutation));
-      // Ensure that any bump is part of this mutation's event group.
-      const group = Blockly.Events.getGroup();
-      setTimeout(function() {
-        Blockly.Events.setGroup(group);
-        block.bumpNeighbours();
-        Blockly.Events.setGroup(false);
-      }, Blockly.BUMP_DELAY);
-    }
-
-    if (oldMutation != newMutation &&
-          this.workspace_.keyboardAccessibilityMode) {
-      Blockly.navigation.moveCursorOnBlockMutation(block);
-    }
-    // Don't update the bubble until the drag has ended, to avoid moving blocks
-    // under the cursor.
-    if (!this.workspace_.isDragging()) {
-      this.resizeBubble_();
-    }
-    Blockly.Events.setGroup(false);
-  }
-};
+// Blockly.Mutator.prototype.workspaceChanged_ = function(e) {
+//   if (e.type == Blockly.Events.UI ||
+//         (e.type == Blockly.Events.CHANGE && e.element == 'disabled')) {
+//     return;
+//   }
+//
+//   if (!this.workspace_.isDragging()) {
+//     const blocks = this.workspace_.getTopBlocks(false);
+//     const MARGIN = 20;
+//     for (let b = 0, block; (block = blocks[b]); b++) {
+//       const blockXY = block.getRelativeToSurfaceXY();
+//       const blockHW = block.getHeightWidth();
+//       if (blockXY.y + blockHW.height < MARGIN) {
+//         // Bump any block that's above the top back inside.
+//         block.moveBy(0, MARGIN - blockHW.height - blockXY.y);
+//       }
+//     }
+//   }
+//
+//   // When the mutator's workspace changes, update the source block.
+//   if (this.rootBlock_.workspace == this.workspace_) {
+//     Blockly.Events.setGroup(true);
+//     const block = this.block_;
+//     const oldMutationDom = block.mutationToDom();
+//     const oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
+//     // Allow the source block to rebuild itself.
+//     block.compose(this.rootBlock_);
+//     block.render();
+//     const newMutationDom = block.mutationToDom();
+//     const newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
+//     if (oldMutation != newMutation) {
+//       Blockly.Events.fire(new Blockly.Events.BlockChange(
+//           block, 'mutation', null, oldMutation, newMutation));
+//       // Ensure that any bump is part of this mutation's event group.
+//       const group = Blockly.Events.getGroup();
+//       setTimeout(function() {
+//         Blockly.Events.setGroup(group);
+//         block.bumpNeighbours();
+//         Blockly.Events.setGroup(false);
+//       }, Blockly.BUMP_DELAY);
+//     }
+//
+//     if (oldMutation != newMutation &&
+//           this.workspace_.keyboardAccessibilityMode) {
+//       Blockly.navigation.moveCursorOnBlockMutation(block);
+//     }
+//     // Don't update the bubble until the drag has ended, to avoid moving blocks
+//     // under the cursor.
+//     if (!this.workspace_.isDragging()) {
+//       this.resizeBubble_();
+//     }
+//     Blockly.Events.setGroup(false);
+//   }
+// };
 
 /**
  * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
  * connected should not coincidentally line up on screen.
  * @override - Due to error in blockly core targeted to be fixed in
  * release 2019 Q4 - delete after replacing with a core containing these fixes
+ *
+ * Released in 2019 Q3
+ * https://github.com/google/blockly/pull/3156
  */
-Blockly.BlockSvg.prototype.bumpNeighbours = function() {
-  if (!this.workspace) {
-    return; // Deleted block.
-  }
-  if (this.workspace.isDragging()) {
-    return; // Don't bump blocks during a drag.
-  }
-  const rootBlock = this.getRootBlock();
-  if (rootBlock.isInFlyout) {
-    return; // Don't move blocks around in a flyout.
-  }
-  // Loop through every connection on this block.
-  /** @type {Blockly.Connection[]} */
-  const myConnections = this.getConnections_(false);
-  /** @type {RenderedConnection} connection */
-  // TODO: Correct assignment/boolean in for/next block
-  for (let i = 0, connection; connection = myConnections[i]; i++) {
-    // connection is of type Blockly.RenderedConnection
-    // Spider down from this block bumping all sub-blocks.
-    if (connection.isConnected() && connection.isSuperior()) {
-      connection.targetBlock().bumpNeighbours();
-    }
-
-    const neighbours = connection.neighbours_(Blockly.SNAP_RADIUS);
-    for (let j = 0, otherConnection; otherConnection = neighbours[j]; j++) {
-      // If both connections are connected, that's probably fine.  But if
-      // either one of them is unconnected, then there could be confusion.
-      if (!connection.isConnected() || !otherConnection.isConnected()) {
-        // Only bump blocks if they are from different tree structures.
-        if (otherConnection.getSourceBlock().getRootBlock() != rootBlock) {
-          // Always bump the inferior block.
-          if (connection.isSuperior()) {
-            otherConnection.bumpAwayFrom_(connection);
-          } else {
-            connection.bumpAwayFrom_(otherConnection);
-          }
-        }
-      }
-    }
-  }
-};
+// Blockly.BlockSvg.prototype.bumpNeighbours = function() {
+//   if (!this.workspace) {
+//     return; // Deleted block.
+//   }
+//   if (this.workspace.isDragging()) {
+//     return; // Don't bump blocks during a drag.
+//   }
+//   const rootBlock = this.getRootBlock();
+//   if (rootBlock.isInFlyout) {
+//     return; // Don't move blocks around in a flyout.
+//   }
+//   // Loop through every connection on this block.
+//   /** @type {Blockly.Connection[]} */
+//   const myConnections = this.getConnections_(false);
+//   /** @type {RenderedConnection} connection */
+//   // TODO: Correct assignment/boolean in for/next block
+//   for (let i = 0, connection; connection = myConnections[i]; i++) {
+//     // connection is of type Blockly.RenderedConnection
+//     // Spider down from this block bumping all sub-blocks.
+//     if (connection.isConnected() && connection.isSuperior()) {
+//       connection.targetBlock().bumpNeighbours();
+//     }
+//     // const nb = connection.getNeighbours( Blockly.SNAP_RADIUS);
+//     const neighbours = connection.neighbours_(Blockly.SNAP_RADIUS);
+//     for (let j = 0, otherConnection; otherConnection = neighbours[j]; j++) {
+//       // If both connections are connected, that's probably fine.  But if
+//       // either one of them is unconnected, then there could be confusion.
+//       if (!connection.isConnected() || !otherConnection.isConnected()) {
+//         // Only bump blocks if they are from different tree structures.
+//         if (otherConnection.getSourceBlock().getRootBlock() != rootBlock) {
+//           // Always bump the inferior block.
+//           if (connection.isSuperior()) {
+//             otherConnection.bumpAwayFrom_(connection);
+//           } else {
+//             connection.bumpAwayFrom_(otherConnection);
+//           }
+//         }
+//       }
+//     }
+//   }
+// };
 
 const isDeprecatedBlockWarningEnabled = function() {
   return WarnDeprecatedBlocks;


### PR DESCRIPTION
Replaces the July 2019 core with the November 2019 core. The new core has no breaking changes.

Updates to the propc.js file to remove functions that override core functions that were buggy. The new core has addresses those issues.