### PR TITLE
Update version display

### DIFF
--- a/src/modules/blockly/generators/propc/sd_card.js
+++ b/src/modules/blockly/generators/propc/sd_card.js
@@ -256,6 +256,7 @@ Blockly.Blocks.sd_read = {
             ['close', 'fclose'],
           ],
           function(mode) {
+            // eslint-disable-next-line no-invalid-this
             this.getSourceBlock().setSdMode(mode);
           }),
           'MODE');
@@ -273,6 +274,7 @@ Blockly.Blocks.sd_read = {
             ['close', 'fclose'],
           ],
           function(mode) {
+            // eslint-disable-next-line no-invalid-this
             this.getSourceBlock().setSdMode(mode);
           }),
           'MODE');
@@ -290,6 +292,7 @@ Blockly.Blocks.sd_read = {
             ['write', 'fwrite'],
           ],
           function(mode) {
+            // eslint-disable-next-line no-invalid-this
             this.getSourceBlock().setSdMode(mode);
           }),
           'MODE');

--- a/src/modules/code_editor.js
+++ b/src/modules/code_editor.js
@@ -41,7 +41,7 @@ let cSourceCode = null;
  * Ace Editor XML code representation
  * @type {AceAjax.Editor | null}
  */
-let cXmlCode = null;
+const cXmlCode = null;
 
 /**
  * Prop c code editor implementing the Ace package

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,7 +44,9 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.5.10-a1';
+export const APP_VERSION = '1.5.10';
+export const APP_BUILD = '201';
+export const APP_QA = 'a2';
 
 /**
  * Set this to target deployment environment.

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -2115,13 +2115,14 @@ function renderContent(id) {
  * @deprecated
  * Feature will be removed soon.
  */
-const formatWizard = function() {
+// eslint-disable-next-line no-unused-vars,require-jsdoc
+function formatWizard() {
   const codePropC = getSourceEditor();
   const currentLine = codePropC.getCursorPosition()['row'] + 1;
   codePropC.setValue(prettyCode(codePropC.getValue()));
   codePropC.focus();
   codePropC.gotoLine(currentLine);
-};
+}
 
 /**
  * Save a project to the local file system

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -32,6 +32,8 @@ import 'bootstrap';
 import * as Cookies from 'js-cookie';
 
 import {
+  APP_BUILD,
+  APP_QA,
   APP_VERSION, ApplicationName, EnableSentry,
   productBannerHostTrigger, TestApplicationName,
 } from './constants';
@@ -67,8 +69,14 @@ function showAppBannerTitle(appName) {
 function setCopyrightDate(element) {
   const d = new Date();
   const year = d.getFullYear().toString();
-  element.innerHTML = `v${APP_VERSION} &copy; 2015 - ${year}, Parallax Inc.`;
+  let applicationVersion = `v${APP_VERSION}`;
+  if (document.location.hostname.toLowerCase().indexOf('solocup') > 0) {
+    applicationVersion += `.${APP_BUILD}-${APP_QA}`;
+  }
+
+  element.innerHTML = `${applicationVersion} &copy; 2015 - ${year}, Parallax Inc.`;
 }
+
 
 /**
  * Set link onClick handlers


### PR DESCRIPTION
Update the version tag emitted on the home page to include 'qa' and the build number for test builds that are targeted at SoloCup.

Correct issues identified by linter.