### PR TITLE
logConsoleMessage & singlequote error fix

### DIFF
--- a/src/modules/toolbar_controller.js
+++ b/src/modules/toolbar_controller.js
@@ -23,7 +23,8 @@
 import {hasCode} from './blocklyc';
 import {getProjectInitialState} from './project.js';
 import {clientService, serviceConnectionTypes} from './client_service';
-import {logConsoleMessage} from "./utility";
+// eslint-disable-next-line no-unused-vars
+import {logConsoleMessage} from './utility';
 
 
 /**


### PR DESCRIPTION
This simple bug is causing all the build errors. You could even delete line `import {logConsoleMessage} from './utility';` fully as it is just formatting a string and sending to the console and its not being used here.