### PR TITLE
Feature select project board type

### DIFF
--- a/src/modules/blockly/generators/propc/procedures.js
+++ b/src/modules/blockly/generators/propc/procedures.js
@@ -745,11 +745,11 @@ Blockly.Blocks['procedures_callnoreturn'] = {
    * @this Blockly.Block
    */
   onchange: function(event) {
-    console.log(`Event: ${event.type}`);
+    // console.log(`Event: ${event.type}`);
 
     if (event.type === Blockly.Events.BLOCK_MOVE) {
       try {
-        console.log(`Block is moving`);
+        // console.log(`Block is moving`);
       } catch (err) {
         console.log(`Block move error: ${err.message}`);
       }
@@ -769,10 +769,10 @@ Blockly.Blocks['procedures_callnoreturn'] = {
           // Cannot set nextStatement to false if there is a block attached
           // below the current block. Detach the block first.
           const nextBlock = this.getNextBlock();
-          console.log(`RunFunction: Bottom block attachment is: ${nextBlock}`);
+          // console.log(`RunFunction: Bottom block attachment is: ${nextBlock}`);
 
           if (nextBlock !== null) {
-            console.log(`NextBlock: ${nextBlock.type.toString()}`);
+            // console.log(`NextBlock: ${nextBlock.type.toString()}`);
             this.nextConnection.disconnect();
           }
           this.setNextStatement(false);
@@ -783,7 +783,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
         this.setNextStatement(true);
       }
     } catch (event) {
-      console.log(event.message);
+      // console.log(event.message);
       this.nextConnection.disconnect();
       this.setNextStatement(false);
     }

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -51,13 +51,13 @@ export const APP_VERSION = '1.5.12';
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '218';
+export const APP_BUILD = '219';
 
 /**
  * Development build stage designator
  * @type {string}
  */
-export const APP_QA = 'a1';
+export const APP_QA = 'release';
 
 /**
  * Set this to target deployment environment.

--- a/src/modules/dialogs/new_project.js
+++ b/src/modules/dialogs/new_project.js
@@ -80,7 +80,7 @@ export const newProjectDialog = {
     }
 
     this.reset();
-    populateProjectBoardTypesUIElement();
+    populateProjectBoardTypesUIElement($('#new-project-board-type'), null);
 
     // Show the New Project modal dialog box
     $('#new-project-dialog').modal({keyboard: false, backdrop: 'static'});
@@ -201,6 +201,8 @@ function newProjectModalEscapeClick() {
 
 /**
  * Populate the UI Project board type drop-down list
+ * @param {HTMLElement} element
+ * @param {string | null} selected
  * @description
  * element is the <select> HTML element that will be populated with a
  * collection of possible board types
@@ -209,26 +211,29 @@ function newProjectModalEscapeClick() {
  * containing the board type in the list that should be designated as the
  * selected board type.
  */
-function populateProjectBoardTypesUIElement() {
-  const element = $('#new-project-board-type');
+export function populateProjectBoardTypesUIElement(element, selected) {
   if (!element) {
     logConsoleMessage(`Unable to find Board Type UI element.`);
     return;
   }
 
+  logConsoleMessage(`Current board type is "${selected}`);
+
   // Clear out the board type dropdown menu
   const length = element[0].options.length;
-  for (let i = length-1; i >= 0; i--) {
+  for (let i = length - 1; i >= 0; i--) {
     element[0].options[i].remove();
   }
 
   // Populate the board type dropdown menu with a header first,
-  element.append($('<option />')
-      .val('')
-      .text(getHtmlText('project_create_board_type_select'))
-      .attr('disabled', 'disabled')
-      .attr('selected', 'selected'),
-  );
+  if (!selected) {
+    element.append($('<option />')
+        .val('')
+        .text(getHtmlText('project_create_board_type_select'))
+        .attr('disabled', 'disabled')
+        .attr('selected', 'selected'),
+    );
+  }
 
   // then populate the dropdown with the board types
   // defined in propc.js in the 'profile' object
@@ -243,9 +248,18 @@ function populateProjectBoardTypesUIElement() {
           if (board !== 'unknown') {
             // Exclude the 'unknown' board type. It is used only when
             // something has gone wrong during a project load operation
-            element.append($('<option />')
-                .val(ProjectProfiles[board].name)
-                .text(ProjectProfiles[board].description));
+            const value = ProjectProfiles[board].name;
+            const description = ProjectProfiles[board].description;
+            if (selected && (value.toUpperCase() === selected.toUpperCase())) {
+              element.append($('<option />')
+                  .attr('selected', 'selected')
+                  .val(value)
+                  .text(description));
+            } else {
+              element.append($('<option />')
+                  .val(value)
+                  .text(description));
+            }
           }
         }
       }

--- a/src/modules/modals.js
+++ b/src/modules/modals.js
@@ -26,6 +26,7 @@ import 'jquery-validation';
 import {displayProjectName} from './editor.js';
 import {getProjectInitialState} from './project';
 import {utils} from './utility';
+import {populateProjectBoardTypesUIElement} from './dialogs/new_project';
 
 /**
  *  Validate the required elements of the edit project form
@@ -73,6 +74,10 @@ export function editProjectDetails() {
   // Display project board type.
   const elementProjectBoardType = $('#edit-project-board-type-ro');
   elementProjectBoardType.html(project.boardType.name.toUpperCase());
+
+  populateProjectBoardTypesUIElement(
+      $('#edit-board-type'),
+      project.boardType.name.toUpperCase());
 
   // Display the project create and last modified time stamps
   const createDate = new Date(project.created);
@@ -136,6 +141,7 @@ function updateProjectDetails() {
       $('#edit-project-name').val(),
       $('#edit-project-description').val(),
   );
+  updateProjectBoardType($('#edit-board-type').val());
 }
 
 /**
@@ -153,6 +159,19 @@ function updateProjectNameDescription(newName, newDescription) {
 
   if (!(project.description === newDescription)) {
     project.description = newDescription;
+  }
+}
+
+/**
+ * Change the project board type if the passed value is different than the current board type
+ *
+ * @param {string} board
+ */
+function updateProjectBoardType(board) {
+  const project = getProjectInitialState();
+  if (project.getBoardName() !== board) {
+    // Change the board type
+    project.setBoardType(board);
   }
 }
 

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -300,6 +300,14 @@ class Project {
   } // End of constructor
 
   /**
+   * Return the name of the current project board type
+   * @return {string}
+   */
+  getBoardName() {
+    return this.boardType.name;
+  }
+
+  /**
      * Get all of the project details in one function call. This is
      * a direct replacement for the code that is converted to JSON
      * to persist the project to storage.
@@ -355,6 +363,9 @@ class Project {
     this.code = newCode;
   }
 
+  setBoardType(name) {
+    this.boardType = Project.convertBoardType(name);
+  }
   /**
    * Setting for code field with namespaced added automatically
    * @param {string} newCode

--- a/src/modules/project.js
+++ b/src/modules/project.js
@@ -363,8 +363,14 @@ class Project {
     this.code = newCode;
   }
 
+  /**
+   * Change the project board type
+   * @param {string} name
+   */
   setBoardType(name) {
-    this.boardType = Project.convertBoardType(name);
+    if (name && (this.boardType.name.toUpperCase() !== name.toUpperCase())) {
+      this.boardType = Project.convertBoardType(name);
+    }
   }
   /**
    * Setting for code field with namespaced added automatically

--- a/src/modules/project/project_io.js
+++ b/src/modules/project/project_io.js
@@ -111,7 +111,7 @@ export const filestreamToProject = (projectName, rawCode) => {
   const projectModified = getProjectModifiedDateFromXML(rawCode, date);
   const projectBoardType = getProjectBoardTypeFromXML(rawCode);
   let projectNameString = getProjectTitleFromXML(rawCode);
-  console.log(`Project Title: ${projectNameString}`);
+
   if (projectNameString === '') {
     projectNameString = projectName;
   }
@@ -186,7 +186,6 @@ function getProjectBoardTypeFromXML(xml) {
 }
 
 
-
 /**
  * Retrieve the project board type from the raw project XML
  * @param {string} xml
@@ -209,15 +208,16 @@ function getProjectTitleFromXML(xml) {
   }
 
   if (title.endsWith('.svg')) {
-    return title.substr(0,title.length - 4);
+    logConsoleMessage(`Stripping ".svg" from project title`);
+    return title.substr(0, title.length - 4);
   }
 
   if (title.endsWith('.svge')) {
-    return title.substr(0,title.length - 5);
+    logConsoleMessage(`Stripping ".svge" from project title`);
+    return title.substr(0, title.length - 5);
   }
 
   return title;
-
 }
 
 /**

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -595,10 +595,22 @@
                             <label for="edit-project-name" class="keyed-lang-string" data-key="project_name"></label>
                             <input type="text" class="form-control form-control-size" id="edit-project-name" name="edit-project-name" />
                         </div>
+
+                        <!-- Edit project board type -->
+                        <div id="edit-project-board-dropdown" class="form-group">
+                            <label for="edit-board-type" class="keyed-lang-string"
+                                   data-key="project_create_board_type"></label>
+                            <select id="edit-board-type" class="form-control form-control-size"
+                                    name="new-project-board-type"></select>
+                        </div>
+
+
                         <!-- project meta data display -->
                         <div id="edit-project-details-ro" class="form-group">
+                            <!--
                             <strong class="keyed-lang-string" data-key="project_create_board_type"></strong>:&nbsp;<span
                                 id="edit-project-board-type-ro"></span><br>
+                            -->
                             <strong class="keyed-lang-string" data-key="project_created"></strong>:&nbsp;<span
                                 id="edit-project-created-date-ro"></span><br>
                             <strong class="keyed-lang-string" data-key="project_modified"></strong>:&nbsp;<span


### PR DESCRIPTION
This update provides support to the Edit Project dialog to change the project board type. There are a number if things that can break if this is used indiscriminately. The primary purpose for this feature is to allow users to correct the project board type that were forced to the 'Flip" type due to an error introduced in release 1.5.11.
