### PR TITLE
Deprecate and remove project fields

### DIFF
--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -51,13 +51,13 @@ export const APP_VERSION = '1.6.0';
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '221';
+export const APP_BUILD = '222';
 
 /**
  * Development build stage designator
  * @type {string}
  */
-export const APP_QA = 'B1';
+export const APP_QA = 'RC1';
 
 /**
  * Set this to target deployment environment.

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -889,9 +889,8 @@ function downloadCode(project) {
   // and hold project metadata.
   const svgHeader = generateSvgHeader( projectWidth, projectHeight );
 
-  // a footer to generate a watermark with the project's information at
-  // the bottom-right corner of the SVG
-  // and hold project metadata.
+  // Generate a watermark with the project's metadate at the bottom-right
+  // corner of the SVG.
   const svgFooter = generateSvgFooter(project);
 
   // Deprecating project checksum. Install a dummy checksum to keep
@@ -996,22 +995,27 @@ function generateSvgFooter( project ) {
             'transform="translate(-225,-83)" style="font-weight:bold;">'+
             'Parallax BlocklyProp Project</text>';
 
-  svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
-            'transform="translate(-225,-68)">' +
-            'User: ' + encodeToValidXml(project.user) + '</text>';
+  // The name of the project owner (deprecated)
+  // svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
+  //           'transform="translate(-225,-68)">' +
+  //           'User: ' + encodeToValidXml(project.user) + '</text>';
 
+  // The project name
   svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
             'transform="translate(-225,-53)">' +
             'Title: ' + encodeToValidXml(project.name) + '</text>';
 
-  svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
-            'transform="translate(-225,-38)">' +
-            'Project ID: 0</text>';
+  // Project ID (deprecated)
+  // svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
+  //           'transform="translate(-225,-38)">' +
+  //           'Project ID: 0</text>';
 
+  // Propeller device attached to the project
   svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
             'transform="translate(-225,-23)">' +
             'Device: ' + project.boardType.name + '</text>';
 
+  // Project description
   svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
             'transform="translate(-225,-8)">' +
             'Description: ' + encodeToValidXml(project.description) + '</text>';

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -1020,8 +1020,10 @@ function generateSvgFooter( project ) {
             'transform="translate(-225,-8)">' +
             'Description: ' + encodeToValidXml(project.description) + '</text>';
 
+  // This transform places the dates outside of the display box and are,
+  // therefore, not visible in the watermark.
   svgFooter += '<text class="bkginfo" x="100%" y="100%" '+
-            'transform="translate(-225,13)" data-createdon="' +
+            'transform="translate(-225,13)">data-createdon="' +
             project.getCreated() + '" data-lastmodified="' + dt + '"></text>';
 
   return svgFooter;

--- a/src/modules/project/project_io.js
+++ b/src/modules/project/project_io.js
@@ -104,19 +104,20 @@ const convertFilestreamToProject = (projectName, rawCode) => {
       Project.getEmptyProjectCodeHeader() + blockCode + '</xml>' :
       Project.getEmptyProjectCodeHeader() + '</xml>';
 
-  // Load the created on and last modified dates. If either date is invalid,
-  // use a known valid date in it's place to keep everything happy.
-  const date = new Date();
-  const projectModified = getProjectModifiedDate(rawCode, date);
-  const projectCreated = getProjectCreatedDate(rawCode, new Date(projectModified));
-
-  const projectDesc = getProjectDescription(rawCode);
-  const projectBoardType = getProjectBoardType(rawCode);
   let projectNameString = getProjectTitle(rawCode);
 
   if (projectNameString === '') {
     projectNameString = projectName;
   }
+
+  const projectDesc = getProjectDescription(rawCode);
+  const projectBoardType = getProjectBoardType(rawCode);
+
+  // Load the created on and last modified dates. If either date is invalid,
+  // use a known valid date in it's place to keep everything happy.
+  const date = new Date();
+  const projectModified = getProjectModifiedDate(rawCode, date);
+  const projectCreated = getProjectCreatedDate(rawCode, new Date(projectModified));
 
   try {
     const tmpBoardType = Project.convertBoardType(projectBoardType);


### PR DESCRIPTION
This update removes the project ID and User fields that were a holdover from the original BlocklyProp project. These fields were populated with static data when a project file was created and were subsequently ignored when the project was loaded from storage.
