### PR TITLE
Updates to disable webpack handling of scss files.

### DIFF
--- a/.github/workflows/solo-develop.yml
+++ b/.github/workflows/solo-develop.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Build SCSS
-        run: npx sass src/sass/main.scss dist/main.css
+        run: npx sass src/scss/main.scss dist/main.css
 
       - name: Run build process
         run: npm run build --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ lib
 .cache
 
 # SASS outputs
-src/sass/*.css
-src/sass/*.map
+src/scss/*.css
+src/scss/*.map

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -20,6 +20,8 @@
  *   DEALINGS IN THE SOFTWARE.
  */
 
+/* Global Colors */
+$color-error: #a94442;
 $color-white: #fff;
 $color-grey: #777;
 
@@ -61,7 +63,6 @@ html, body {
   max-height: 110% !important;
 }
 
-
 /* Solo-50 Keep mouse pointer from changing to an i-bar */
 .dropdown-menu>li>a {
   cursor: pointer;
@@ -70,7 +71,7 @@ html, body {
 
 /* Style form validation error message */
 .error {
-  color: #a94442;
+  color: $color-error;
   background-color: #f2dede;
   border-color: #ebccd1;
   padding:1px 20px 1px 20px;
@@ -475,7 +476,7 @@ ul > hr {
   line-height:20px;
   padding: 4px 4px 4px 0;
   text-decoration:none;
-  text-size-adjust:100%;
+/*   text-size-adjust:100%;  */
   width:auto;
   -webkit-tap-highlight-color:rgba(0, 0, 0, 0);
 }
@@ -496,7 +497,7 @@ ul > hr {
   line-height:20px;
   padding:4px;
   text-decoration:none;
-  text-size-adjust:100%;
+/*   text-size-adjust:100%;  */
   width:auto;
   -webkit-tap-highlight-color:rgba(0, 0, 0, 0);
 }
@@ -517,7 +518,7 @@ ul > hr {
   line-height:20px;
   padding:4px;
   text-decoration:none;
-  text-size-adjust:100%;
+/*  text-size-adjust:100%;  */
   width:auto;
   -webkit-tap-highlight-color:rgba(0, 0, 0, 0);
 }

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -131,7 +131,7 @@ module.exports = (opts) => {
         patterns: [
           {from: path.resolve(__dirname, blocklyMedia), to: path.resolve(__dirname, `${targetPath}/media`)},
           {from: './src/images', to: path.resolve(__dirname, `${targetPath}/images`)},
-          {from: './src/scss/main.css', to: path.resolve(__dirname, targetPath)},
+          // {from: './src/scss/main.css', to: path.resolve(__dirname, targetPath)},
           {from: './src/load_images.js', to: path.resolve(__dirname, targetPath)},
         ]
       })

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -85,18 +85,21 @@ module.exports = (opts) => {
       ],
     },
     module: {
-      rules: [
-        {
-          test: /\.s[ac]ss$/i,
-          use: [
-            // Creates `style` nodes from JS strings
-            "style-loader",
-            // Translates CSS into CommonJS
-            "css-loader",
-            // Compiles Sass to CSS
-            "sass-loader",
-          ],
-        },
+      // rules: [
+      //   {
+      //     test: /\.s[ac]ss$/i,
+      //       include: [
+      //         path.resolve(__dirname, './src/sass')
+      //       ],
+      //     use: [
+      //       // Creates `style` nodes from JS strings
+      //       "style-loader",
+      //       // Translates CSS into CommonJS
+      //       "css-loader",
+      //       // Compiles Sass to CSS
+      //       "sass-loader",
+      //     ],
+      //   },
         //
         // {
         //   test: /\.css$/,
@@ -108,7 +111,7 @@ module.exports = (opts) => {
         //     'css-loader'
         //   ]
         // },
-      ]
+      // ]
     },
     plugins: [
       new webpack.EnvironmentPlugin({
@@ -128,7 +131,7 @@ module.exports = (opts) => {
         patterns: [
           {from: path.resolve(__dirname, blocklyMedia), to: path.resolve(__dirname, `${targetPath}/media`)},
           {from: './src/images', to: path.resolve(__dirname, `${targetPath}/images`)},
-          // {from: './sass/main.css', to: path.resolve(__dirname, targetPath)},
+          {from: './src/scss/main.css', to: path.resolve(__dirname, targetPath)},
           {from: './src/load_images.js', to: path.resolve(__dirname, targetPath)},
         ]
       })


### PR DESCRIPTION
I am unable to get webpack to compile scss files and place the results in the ./dist folder for production deployment.  The workaround is to use a webpack copy asset to copy the compiled .css file to the ./dist folder during production build.