### PR TITLE
Replace plain Javascript with jQuery that supports .modal() method.

### DIFF
--- a/src/modules/client_connection.js
+++ b/src/modules/client_connection.js
@@ -566,7 +566,6 @@ export const getComPort = function() {
  */
 const hideCompilerStatusWindow = () => {
   console.log('Hide Compiler dialog window.');
-  const dialog = document.getElementById('compile-dialog');
-  dialog.modal('hide');
+  $('#compile-dialog').modal('hide');
 };
 


### PR DESCRIPTION
The HtmlElement object does not support a .modal() method. This method is specific to jQuery, sp a jQuery selector must be used when invoking the modal() method.

Addresses issue #661 
