### PR TITLE
Correct path in SASS compile script. (more)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "webpack --config webpack/prod.config.js --node-env production --stats",
     "build:deploy": "rm -rdf ./dist/*; npm run build:sass;  webpack --config webpack/prod.config.js --node-env production --stats",
     "build:analyze": "npm run build -- --env.addons=bundleanalyzer",
-    "build:sass": "npx sass src/sass/main.scss dist/main.css",
+    "build:sass": "npx sass src/scss/main.scss dist/main.css",
     "build:test": "ls ./dist/*",
     "lint": "eslint \"src/modules/**/*.js\"",
     "profile": "webpack --profile --json --config webpack/dev.config.js > stats.json",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "homepage": "https://github.com/parallaxinc/solo#readme",
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.4",
-    "@sentry/browser": "^6.3.6",
-    "@sentry/tracing": "^6.3.6",
+    "@sentry/browser": "^6.10.0",
+    "@sentry/tracing": "^6.10.0",
     "ace-builds": "^1.4.8",
     "blockly": "^3.20191014.4",
     "bootbox": "^5.4.0",


### PR DESCRIPTION
Update the Sentry packages to version 6.10.0.

Addresses issues #660 and #662.