### PR TITLE
Bump the build number. Release patch for compiler dialog fault.

### DIFF
--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -51,13 +51,13 @@ export const APP_VERSION = '1.6.0';
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '222';
+export const APP_BUILD = '224';
 
 /**
  * Development build stage designator
  * @type {string}
  */
-export const APP_QA = 'RC1';
+export const APP_QA = 'Update-1';
 
 /**
  * Set this to target deployment environment.


### PR DESCRIPTION
Release 1.6.0-update-1 to correct  a TypeError when the Launcher sends a message to the client to close the Cloud Compiler dialog window.
