### PR TITLE
Patch more constants

### DIFF
--- a/src/modules/blockly/generators/propc/sensors/sensors_common.js
+++ b/src/modules/blockly/generators/propc/sensors/sensors_common.js
@@ -22,6 +22,7 @@
 
 
 import Blockly from 'blockly/core';
+import {getDefaultProfile} from '../../../../project';
 
 /**
  * Build a list of user-defined constant values
@@ -82,4 +83,13 @@ export function verifyBlockTypeEnabled( type ) {
   });
 
   return enabled;
+}
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Retrieve the digital array of the project board type.
+ * @return {string[][] | *}
+ */
+export function getProfileDigital() {
+  return getDefaultProfile().digital;
 }


### PR DESCRIPTION
This update provides more fine-grained handling of constant values in the pin list. When a constant block is deleted, we now check to see if this constant is the currently assigned pin. If it is, we complain to the console and set the pin value to the first element of the pin list. Otherwise, the deleted constant is removed from the pin list.

When a constant block is created or restored from the trash can, we now add that constant to the pin list.