### PR TITLE
Update change management for references to constant blocks

### DIFF
--- a/src/modules/blockly/generators/propc/propc_common.js
+++ b/src/modules/blockly/generators/propc/propc_common.js
@@ -35,11 +35,14 @@ export function buildConstantsList() {
 
   const allBlocks = Blockly.getMainWorkspace().getBlocksByType(BLOCK_TYPE, false);
   for (let x = 0; x < allBlocks.length; x++) {
-    const vName = allBlocks[x].getFieldValue('CONSTANT_NAME');
-    if (vName) {
-      userDefinedConstantsList.push(vName);
+    if (allBlocks[x].isEnabled()) {
+      const vName = allBlocks[x].getFieldValue('CONSTANT_NAME');
+      if (vName) {
+        userDefinedConstantsList.push(vName);
+      }
     }
   }
+
   return userDefinedConstantsList.sortedUnique();
 }
 
@@ -83,6 +86,16 @@ export function verifyBlockTypeEnabled( type ) {
   });
 
   return enabled;
+}
+
+/**
+ * Verify that the block specified is enabled
+ * @param {string} id
+ * @return {boolean}
+ */
+export function verifyBlockIdEnabled( id ) {
+  const block = Blockly.getMainWorkspace().getBlockById(id);
+  return (block && block.isEnabled());
 }
 
 // eslint-disable-next-line valid-jsdoc

--- a/src/modules/blockly/generators/propc/sensors/sound_impact.js
+++ b/src/modules/blockly/generators/propc/sensors/sound_impact.js
@@ -87,16 +87,30 @@ Blockly.Blocks.sound_impact_run = {
    * the old value to see if it is in this object's list of known constants.
    * If changing constant is used, reset the pin list to replace the old
    * constant name with the new one.
+   *
+   * NOTE: This does not handle the use case where the constant block is
+   * disabled. The emitted source code does not include the constant defined
+   * by the disabled block. This will create a compile error when the constant
+   * represented by the disabled block is used elsewhere in the project.
    */
   onchange: function(event) {
     const BLOCK_TYPE = 'CONSTANT_NAME';
-    if (event.type === 'change' && event.name === BLOCK_TYPE) {
-      // Change only if the selected pin is the named constant that is changing
-      if (this.getFieldValue('PIN') === event.oldValue) {
-        const index = this.userDefinedConstantsList_.indexOf(event.oldValue);
-        if (index !== -1) {
-          this.userDefinedConstantsList_[index] = event.newValue;
+
+    if (event.type === Blockly.Events.BLOCK_CHANGE &&
+        (event.name && event.name === BLOCK_TYPE)) {
+      // A constant value is changing. If the old (previous) value is in the pin
+      // list, we need to update the pin list to reflect the change.
+      const index = this.userDefinedConstantsList_.indexOf(event.oldValue);
+      if (index !== -1) {
+        // Save the current state of the pin in case it is the constant being changed.
+        const currentPinValue = this.getFieldValue('PIN');
+        this.userDefinedConstantsList_[index] = event.newValue;
+
+        // Change the selected pin name to the new value
+        if (currentPinValue === event.oldValue) {
           this.setPinMenus(event.oldValue, event.newValue);
+        } else {
+          this.setPinMenus();
         }
       }
     }


### PR DESCRIPTION
BuildConstantsList() now ignores disabled constant blocks. This has the effect of removing the disabled constant from the refreshed pin list.

Correct error where a disabled block does not have an event.name. A change event is triggered when any block is disabled. The event object that is passed into the change handler does not have a 'name' property, so name of the block that was disabled is not readily discernible. The change handler now verifies that the name property is available before using it.