### PR TITLE
Update Blockly Core to v3.20200924.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/browser": "^6.10.0",
         "@sentry/tracing": "^6.10.0",
         "ace-builds": "^1.4.8",
-        "blockly": "^3.20191014.4",
+        "blockly": "^3.20200924.4",
         "bootbox": "^5.4.0",
         "bootstrap": "^3.4.1",
         "chartist": "^0.11.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@sentry/browser": "^6.10.0",
     "@sentry/tracing": "^6.10.0",
     "ace-builds": "^1.4.8",
-    "blockly": "^3.20191014.4",
+    "blockly": "^3.20200924.4",
     "bootbox": "^5.4.0",
     "bootstrap": "^3.4.1",
     "chartist": "^0.11.4",

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -24,7 +24,7 @@
  * Global flag to enable/disable the Sentry logger
  * @type {boolean}
  */
-export const EnableSentry = false;
+export const EnableSentry = true;
 
 /**
  * Set the application version string
@@ -51,7 +51,7 @@ export const APP_VERSION = '1.6.2';
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '230';
+export const APP_BUILD = '231';
 
 /**
  * Development build stage designator

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -136,6 +136,8 @@ function getWorkspaceSvg() {
  * Replaces the old document.ready() construct
  */
 $(() => {
+  logConsoleMessage(`Blockly Core: ${Blockly.VERSION}`);
+
   // This will initiate a number of async calls to set up the page
   const result = initializePage();
   result.catch((err) => console.log(err));


### PR DESCRIPTION
This is the last release of the '3' series Blockly Core. It get way more interesting from here.

Enable Sentry.