### PR TITLE
Patch SD file exist

### DIFF
--- a/src/modules/blockly/generators/propc.js
+++ b/src/modules/blockly/generators/propc.js
@@ -270,6 +270,7 @@ Blockly.propc.finish = function(code) {
     }
   }
 
+  // Adding variable declarations here
   for (const def in definitions) {
     if (Object.prototype.hasOwnProperty.call(definitions, def)) {
       for (const variable in Blockly.propc.vartype_) {

--- a/src/modules/blockly/generators/propc/sd_card.js
+++ b/src/modules/blockly/generators/propc/sd_card.js
@@ -611,7 +611,7 @@ Blockly.Blocks['sd_file_exists'] = {
             }), 'FILENAME');
 
     this.setInputsInline(false);
-    this.setOutput(true, 'Boolean');
+    this.setOutput(true, 'Number');
   },
 };
 
@@ -625,7 +625,8 @@ Blockly.propc.sd_file_exists = function() {
   code += `p = fopen(name,"r");\n\t`;
   code += `if (NULL != p) {\n\t\t`;
   code += `result = 1;\n\t\t`;
-  code += `fclose(p);\n\t}\n\t`;
+  code += `fclose(p);\n\t\t`;
+  code += `p = 0;\n\t}\n\t`;
   code += `return result;\n`;
   code += `}\n`;
 
@@ -634,6 +635,6 @@ Blockly.propc.sd_file_exists = function() {
   // code = Blockly.propc.scrub_(this, code);
   Blockly.propc.methods_['file_exists'] = code;
 
-  const emit = `file_exists("${filename}");`;
+  const emit = `(int) file_exists("${filename}");`;
   return [emit, Blockly.propc.ORDER_ATOMIC];
 };

--- a/src/modules/blockly/generators/propc/variables.js
+++ b/src/modules/blockly/generators/propc/variables.js
@@ -111,7 +111,7 @@ Blockly.propc.variables_set = function() {
   const varName = Blockly.propc.variableDB_.getName(
       this.getFieldValue('VAR'),
       Blockly.VARIABLE_CATEGORY_NAME);
-
+  // Look for a type declaration for the variable
   if (Blockly.propc.vartype_[varName] === undefined) {
     if (argument0.indexOf('int') > -1) {
       Blockly.propc.vartype_[varName] = 'int';


### PR DESCRIPTION
When the  file_exist() function is assigned to a variable, the return type of the function must be declared in the emitted code. Failure to do so causes the emitter code builder in propc.js to declare the variable as type 'float'.

```
  // Check for the file we just wrote
  item = (int) file_exists("filename.txt");;
  print("Hello");
```

There are some odd things happening in propc.js around line 274 where the code is parsing definitions and assigning variable types. Without the ``` (int)``` type declaration in the emitted code, the parser declares the function as a float because it finds a decimal point in the first argument,  ```argument0 = "file_exists(\"filename.txt\");"```. With the int cast, the code searches for an int declaration when the function is used and subsequently types the assigned variable as a type int and not a type float.
