### PR TITLE
Release 1.6.3

### DIFF
--- a/src/modules/blockly/generators/propc/sd_card.js
+++ b/src/modules/blockly/generators/propc/sd_card.js
@@ -589,6 +589,7 @@ Blockly.Blocks['sd_file_exists'] = {
 
 /**
  * Generate the C source code to support the File Exists block
+ * @return {[string, number]}
  */
 Blockly.propc.sd_file_exists = function() {
   const filename = this.getFieldValue('FILENAME');
@@ -621,7 +622,7 @@ Blockly.propc.sd_file_exists = function() {
 /**
  * Mount SD Card
  */
- function setupSdCard() {
+function setupSdCard() {
   const profile = getDefaultProfile();
   if (profile.sd_card) {
     Blockly.propc.setups_['sd_card'] = 'sd_mount(' + profile.sd_card + ');';

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,14 +44,14 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.6.2';
+export const APP_VERSION = '1.6.3';
 
 /**
  * Incremental build number. This gets updated before any release
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '231';
+export const APP_BUILD = '232';
 
 /**
  * Development build stage designator
@@ -65,6 +65,7 @@ export const APP_QA = 'Beta-1';
  * This is a temporary use while environment variables are implemented.
  * @type {string}
  */
+// export const APP_STAGE = 'TEST';
 export const APP_STAGE = 'PROD';
 
 /**
@@ -132,3 +133,6 @@ export const TestApplicationName = 'Solocup';
  * @type {boolean}
  */
 export const WarnDeprecatedBlocks = false;
+
+
+export const ClientDownloadURIRoot = 'https://media.parallax.com/blockly';

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -70,10 +70,20 @@ import {
   downloadCSV, graphingConsole, configureConnectionPaths,
   graphPlay, downloadGraph, graphStartStop,
 } from './blocklyc';
+
 import {serialConsole} from './serial_console';
 import {findClient} from './client_connection';
 import {clientService, initTerminal} from './client_service';
-import {APP_BUILD, APP_QA, APP_VERSION, EnableSentry, LOCAL_PROJECT_STORE_NAME} from './constants';
+
+import {
+  APP_BUILD,
+  APP_QA,
+  APP_VERSION,
+  ClientDownloadURIRoot,
+  EnableSentry,
+  LOCAL_PROJECT_STORE_NAME,
+} from './constants';
+
 import {PROJECT_NAME_MAX_LENGTH} from './constants';
 import {PROJECT_NAME_DISPLAY_MAX_LENGTH, ApplicationName} from './constants';
 import {TestApplicationName, productBannerHostTrigger} from './constants';
@@ -478,48 +488,46 @@ function leavePageHandler() {
  * HTML meta tag.
  */
 async function initClientDownloadLinks() {
-  const uriRoot = 'http://downloads.parallax.com/blockly';
-
   // BP Client for Windows 32-bit
   $('.client-win32-link')
-      .attr('href', `${uriRoot}/clients/BlocklyPropClient-setup-32.exe`);
+      .attr('href', `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-32.exe`);
   $('.client-win32zip-link')
-      .attr('href', `${uriRoot}/clients/BlocklyPropClient-setup-32.zip`);
+      .attr('href', `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-32.zip`);
 
   // BP Client for Windows 64-bit
   $('.client-win64-link')
       .attr('href',
-          `${uriRoot}/clients/BlocklyPropClient-setup-64.exe`);
+          `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-64.exe`);
   $('.client-win64zip-link')
       .attr('href',
-          `${uriRoot}/clients/BlocklyPropClient-setup-64.zip`);
+          `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-64.zip`);
 
   // BP Launcher for Windows
   $('.launcher-win64-link')
       .attr('href',
-          `${uriRoot}/launcher/Setup-BPLauncher-Win.exe`);
+          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-Win.exe`);
   $('.launcher-win64zip-link')
       .attr('href',
-          `${uriRoot}/launcher/Setup-BPLauncher-Win.exe.zip`);
+          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-Win.exe.zip`);
 
   // BP Client for MacOS
   $('.client-mac-link')
       .attr('href',
-          `${uriRoot}/clients/BlocklyPropClient-setup-MacOS.pkg`);
+          `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-MacOS.pkg`);
 
   // BP Launchers for MacOS
   $('.launcher-mac-link-big-sur')
       .attr('href',
-          `${uriRoot}/launcher/Setup-BPLauncher-MacOS-Big-Sur.zip`);
+          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-Big-Sur.zip`);
   $('.launcher-mac-link-catalina')
       .attr('href',
-          `${uriRoot}/launcher/Setup-BPLauncher-MacOS-Catalina.zip`);
+          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-Catalina.zip`);
   $('.launcher-mac-link-mojave')
       .attr('href',
-          `${uriRoot}/launcher/Setup-BPLauncher-MacOS-Mojave.zip`);
+          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-Mojave.zip`);
   $('.launcher-mac-link-high_sierra')
       .attr('href',
-          `${uriRoot}/launcher/Setup-BPLauncher-MacOS-High-Sierra.zip`);
+          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-High-Sierra.zip`);
 }
 
 /**


### PR DESCRIPTION
Interim release to address an issue where Chrome no longer permits secured pages to link to insecure URLs. 
Addresses issue #703 
