### PR TITLE
Add comment elements to variable blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2358,7 +2358,6 @@
     },
     "node_modules/chokidar/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5502,7 +5501,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/inquirer": {
       "version": "7.0.0",
@@ -17108,7 +17108,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "inquirer": {
       "version": "7.0.0",

--- a/src/modules/blockly/generators/propc/variables.js
+++ b/src/modules/blockly/generators/propc/variables.js
@@ -33,6 +33,7 @@
 
 import Blockly from 'blockly/core.js';
 import {colorPalette} from '../propc.js';
+import {ShowBlockComments} from '../../../constants';
 
 /**
  * This is a counter used to provide unique array identifiers
@@ -61,6 +62,14 @@ Blockly.Blocks.variables_get = {
         .appendField(new Blockly.FieldVariable(
             Blockly.LANG_VARIABLES_GET_ITEM), 'VAR');
     this.setOutput(true);
+    this.setCommentText(
+        ShowBlockComments? 'This block retrieves the value of a variable. [variables_get]': null);
+
+    /**
+     * This does not appear to be used anywhere.
+     * @type {null}
+     * @deprecated
+     */
     this.typeCheckRun = null;
   },
 };
@@ -94,6 +103,8 @@ Blockly.Blocks.variables_set = {
         .appendField('=');
     this.setPreviousStatement(true, 'Block');
     this.setNextStatement(true);
+    this.setCommentText(
+        ShowBlockComments ? 'This block assigns a value to a variable. [variables_set]' : null);
   },
 };
 

--- a/src/modules/blockly/generators/propc/variables.js
+++ b/src/modules/blockly/generators/propc/variables.js
@@ -29,7 +29,6 @@
  *         kgracey@parallax.com      (Ken Gracey)
  *         carsongracey@gmail.com    (Carson Gracey)
  */
-'use strict';
 
 import Blockly from 'blockly/core.js';
 import {colorPalette} from '../propc.js';
@@ -57,8 +56,8 @@ Blockly.Blocks.variables_get = {
   init: function() {
     this.setTooltip(Blockly.MSG_VARIABLES_GET_TOOLTIP);
     this.setColour(colorPalette.getColor('variables'));
-    this.appendDummyInput('')
-        .appendField(Blockly.LANG_VARIABLES_GET_TITLE_1)
+
+    this.appendDummyInput('get_variable')
         .appendField(new Blockly.FieldVariable(
             Blockly.LANG_VARIABLES_GET_ITEM), 'VAR');
     this.setOutput(true);
@@ -86,6 +85,7 @@ Blockly.propc.variables_get = function() {
   return [code, Blockly.propc.ORDER_ATOMIC];
 };
 
+
 /**
  *  Variable setter.
  *
@@ -96,11 +96,11 @@ Blockly.Blocks.variables_set = {
   init: function() {
     this.setTooltip(Blockly.MSG_VARIABLES_SET_TOOLTIP);
     this.setColour(colorPalette.getColor('variables'));
+
     this.appendValueInput('VALUE')
-        .appendField(Blockly.LANG_VARIABLES_SET_TITLE_1)
-        .appendField(new Blockly.FieldVariable(
-            Blockly.LANG_VARIABLES_SET_ITEM), 'VAR')
+        .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_SET_ITEM), 'VAR')
         .appendField('=');
+
     this.setPreviousStatement(true, 'Block');
     this.setNextStatement(true);
     this.setCommentText(

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -44,14 +44,14 @@ export const EnableSentry = true;
  *     {b#} is the beta release number.
  *     {rc#} is the release candidate number.
  */
-export const APP_VERSION = '1.6.3';
+export const APP_VERSION = '1.6.4';
 
 /**
  * Incremental build number. This gets updated before any release
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '232';
+export const APP_BUILD = '233';
 
 /**
  * Development build stage designator
@@ -132,7 +132,17 @@ export const TestApplicationName = 'Solocup';
  *
  * @type {boolean}
  */
-export const WarnDeprecatedBlocks = false;
+export const WarnDeprecatedBlocks = true;
 
 
 export const ClientDownloadURIRoot = 'https://media.parallax.com/blockly';
+
+/**
+ * Global flag to enable / disable the comment element with each block
+ * @type {boolean}
+ * @description Block comments offer a brief explanation of the blocks function
+ * and an identifier to help developers locate the block source code. Comment
+ * blocks are automatically enabled in the 'TEST' environment and disabled in
+ * the 'PRODUCTION' environment.
+ */
+export const ShowBlockComments = (APP_STAGE === 'TEST');


### PR DESCRIPTION
Adds popup comments to the variable blocks to help identification of the blocks when used on the workspace. 
Removed unused field references.
