### PR TITLE
Add updates to support new launcher release for macOS Ventura.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "compile:sass": "sass src/scss/main.scss dist/main.css",
-    "dev": "npm run build:sass; webpack --config webpack/dev.config.js --node-env development",
+    "dev": "rm -rdf ./dist/*; npm run build:sass; webpack --config webpack/dev.config.js --node-env development",
     "dev:analyze": "npm run dev -- --env.addons=bundleanalyzer",
     "build": "webpack --config webpack/prod.config.js --node-env production --stats",
     "build:deploy": "rm -rdf ./dist/*; npm run build:sass;  webpack --config webpack/prod.config.js --node-env production --stats",

--- a/src/modules/blockly/language/en/page_text_labels.js
+++ b/src/modules/blockly/language/en/page_text_labels.js
@@ -117,15 +117,20 @@ PageTextLabels['client_windows_run_title'] = 'Running the BlocklyProp Launcher o
 PageTextLabels['client_windows_run_instructions1'] = 'Click the Windows (start) icon in the lower-left corner of your screen. Then look for the BlocklyProp Launcher application inside of the &quot;Parallax Inc&quot; folder:';
 PageTextLabels['client_chrome_run_title'] = 'Running the BlocklyProp Launcher on your Chromebook';
 PageTextLabels['client_chrome_run_instructions1'] = 'Click the App icon (circle) in the bottom-left corner of the screen. Find the BlocklyProp Launcher app and double-click it:';
-PageTextLabels['clientdownload_download_installer'] = 'Download the installer';
 
 // MacOS Launcher installations
-PageTextLabels['client_download_launcher_macos_big_sur_installer'] = 'BP-Launcher installer for MacOS Big Sur';
-PageTextLabels['client_download_launcher_macos_catalina_installer'] = 'BP-Launcher installer for MacOS Catalina';
-PageTextLabels['client_download_launcher_macos_mojave_installer'] = 'BP-Launcher installer for MacOS Mojave';
-PageTextLabels['client_download_launcher_macos_high_sierra_installer'] = 'BP-Launcher installer for MacOS High Sierra';
+PageTextLabels['client_download_launcher_macos_ventura_installer'] = 'BP-Launcher installer for macOS Ventura';
+PageTextLabels['client_download_launcher_macos_monterey_installer'] = 'BP-Launcher installer for macOS Monterey';
+PageTextLabels['client_download_launcher_macos_big_sur_installer'] = 'BP-Launcher installer for macOS Big Sur';
+PageTextLabels['client_download_launcher_macos_catalina_installer'] = 'BP-Launcher installer for macOS Catalina';
+PageTextLabels['client_download_launcher_macos_mojave_installer'] = 'BP-Launcher installer for macOS Mojave';
+PageTextLabels['client_download_launcher_macos_high_sierra_installer'] = 'BP-Launcher installer for macOS High Sierra';
+
+// Windows Launcher installations
 PageTextLabels['clientdownload_launcher_windows64_installer'] = 'Windows 7/8/8.1/10 (64-bit) BP-Launcher installer';
 PageTextLabels['clientdownload_launcher_windows64zip_installer'] = 'Windows 7/8/8.1/10 (64-bit) BP-Launcher installer (zip)';
+
+PageTextLabels['clientdownload_download_installer'] = 'Download the installer';
 PageTextLabels['clientdownload_download_launcher'] = 'Install the Launcher App';
 PageTextLabels['clientdownload_client_chromeos_installer'] = 'Add to Chrome';
 PageTextLabels['clientdownload_os_menu'] = 'Choose a different operating system';
@@ -134,7 +139,7 @@ PageTextLabels['menu_code'] = 'Code';
 PageTextLabels['menu_blocks'] = 'Blocks';
 
 PageTextLabels['os_name_win'] = 'Windows';
-PageTextLabels['os_name_mac'] = 'Mac OS';
+PageTextLabels['os_name_mac'] = 'macOS';
 PageTextLabels['os_name_chr'] = 'Chrome OS';
 
 /**

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -51,7 +51,7 @@ export const APP_VERSION = '1.6.4';
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '236';
+export const APP_BUILD = '243';
 
 /**
  * Development build stage designator

--- a/src/modules/editor.js
+++ b/src/modules/editor.js
@@ -61,7 +61,7 @@ import './blockly/generators/propc/sensors/sound_impact';
 
 import './blockly/generators/propc/variables';
 
-import {compile, loadInto, initializeBlockly, configureConnectionPaths } from './blocklyc';
+import {compile, loadInto, initializeBlockly, configureConnectionPaths} from './blocklyc';
 import {downloadCSV, graphingConsole, graphPlay, downloadGraph, graphStartStop} from './graph';
 
 import {serialConsole} from './serial_console';
@@ -340,12 +340,12 @@ function initEventHandlers() {
 
   // Save As button
   $('#save-as-btn').on('click', () => saveAsDialog());
+
   // Save-As Project
   $('#save-project-as').on('click', () => saveAsDialog());
 
   // Save As new board type
-  $('#save-as-board-type').on('change', () => checkBoardType(
-      $('#saveAsDialogSender').html()));
+  $('#save-as-board-type').on('change', () => checkBoardType($('#saveAsDialogSender').html()));
 
   // popup modal
   $('#save-as-board-btn').on('click', () => saveProjectAs(
@@ -469,50 +469,56 @@ function leavePageHandler() {
  * Set the BlocklyProp Client download links
  *
  * Set the href for each of the client links to point to the correct files
- * available on the downloads.parallax.com S3 site. The URL is stored in a
+ * available on the downloads.parallax.com S3 site. The URL is stored in an
  * HTML meta tag.
+ *
+ * Be sure to update the text for these links in
+ * modules/blockly/language/en/page_Text_labels.js
  */
 async function initClientDownloadLinks() {
   // BP Client for Windows 32-bit
-  $('.client-win32-link')
-      .attr('href', `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-32.exe`);
-  $('.client-win32zip-link')
-      .attr('href', `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-32.zip`);
+  $('.client-win32-link').attr('href',
+      `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-32.exe`);
+
+  $('.client-win32zip-link').attr('href',
+      `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-32.zip`);
 
   // BP Client for Windows 64-bit
-  $('.client-win64-link')
-      .attr('href',
-          `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-64.exe`);
-  $('.client-win64zip-link')
-      .attr('href',
-          `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-64.zip`);
+  $('.client-win64-link').attr('href',
+      `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-64.exe`);
+
+  $('.client-win64zip-link').attr('href',
+      `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-64.zip`);
 
   // BP Launcher for Windows
-  $('.launcher-win64-link')
-      .attr('href',
-          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-Win.exe`);
-  $('.launcher-win64zip-link')
-      .attr('href',
-          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-Win.exe.zip`);
+  $('.launcher-win64-link').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-Win.exe`);
 
-  // BP Client for MacOS
-  $('.client-mac-link')
-      .attr('href',
-          `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-MacOS.pkg`);
+  $('.launcher-win64zip-link').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-Win.exe.zip`);
 
-  // BP Launchers for MacOS
-  $('.launcher-mac-link-big-sur')
-      .attr('href',
-          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-Big-Sur.zip`);
-  $('.launcher-mac-link-catalina')
-      .attr('href',
-          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-Catalina.zip`);
-  $('.launcher-mac-link-mojave')
-      .attr('href',
-          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-Mojave.zip`);
-  $('.launcher-mac-link-high_sierra')
-      .attr('href',
-          `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-MacOS-High-Sierra.zip`);
+  // BP Client for macOS
+  $('.client-mac-link').attr('href',
+      `${ClientDownloadURIRoot}/clients/BlocklyPropClient-setup-MacOS.pkg`);
+
+  // BP Launchers for macOS
+  $('.launcher-mac-link-ventura').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-macOS-Ventura.zip`);
+
+  $('.launcher-mac-link-monterey').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-macOS-Monterey.zip`);
+
+  $('.launcher-mac-link-big-sur').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-macOS-Big-Sur.zip`);
+
+  $('.launcher-mac-link-catalina').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-macOS-Catalina.zip`);
+
+  $('.launcher-mac-link-mojave').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-macOS-Mojave.zip`);
+
+  $('.launcher-mac-link-high_sierra').attr('href',
+      `${ClientDownloadURIRoot}/launcher/Setup-BPLauncher-macOS-High-Sierra.zip`);
 }
 
 /**

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -844,6 +844,18 @@
                         <!-- MacOS Launcher download link -->
                         <div class="client MacOS">
                             <img src="images/icons/os/mac_os.png" alt="Mac OS icon" />
+                            <a href="#" class="launcher-mac-link-ventura">
+                                <span class="keyed-lang-string"
+                                      data-key="client_download_launcher_macos_ventura_installer"></span></a>
+                        </div>
+                        <div class="client MacOS">
+                            <img src="images/icons/os/mac_os.png" alt="Mac OS icon" />
+                            <a href="#" class="launcher-mac-link-monterey">
+                                <span class="keyed-lang-string"
+                                      data-key="client_download_launcher_macos_monterey_installer"></span></a>
+                        </div>
+                        <div class="client MacOS">
+                            <img src="images/icons/os/mac_os.png" alt="Mac OS icon" />
                             <a href="#" class="launcher-mac-link-big-sur">
                                 <span class="keyed-lang-string"
                                       data-key="client_download_launcher_macos_big_sur_installer"></span></a>


### PR DESCRIPTION
The previous version of the launcher was failing when installed in a Mac running macOS Ventura. The launcher package was updated and released as version [1.0.7](https://github.com/parallaxinc/BlocklyPropLauncher/pull/131).

The Mac operating system text references were changed from MacOS to macOS.