### PR TITLE
Correct text to include Windows 11 and remove Windows 7.

### DIFF
--- a/src/modules/blockly/language/en/page_text_labels.js
+++ b/src/modules/blockly/language/en/page_text_labels.js
@@ -127,8 +127,8 @@ PageTextLabels['client_download_launcher_macos_mojave_installer'] = 'BP-Launcher
 PageTextLabels['client_download_launcher_macos_high_sierra_installer'] = 'BP-Launcher installer for macOS High Sierra';
 
 // Windows Launcher installations
-PageTextLabels['clientdownload_launcher_windows64_installer'] = 'Windows 7/8/8.1/10 (64-bit) BP-Launcher installer';
-PageTextLabels['clientdownload_launcher_windows64zip_installer'] = 'Windows 7/8/8.1/10 (64-bit) BP-Launcher installer (zip)';
+PageTextLabels['clientdownload_launcher_windows64_installer'] = 'Windows 8/8.1/10/11 (64-bit) BP-Launcher installer';
+PageTextLabels['clientdownload_launcher_windows64zip_installer'] = 'Windows 8/8.1/10/11 (64-bit) BP-Launcher installer (zip)';
 
 PageTextLabels['clientdownload_download_installer'] = 'Download the installer';
 PageTextLabels['clientdownload_download_launcher'] = 'Install the Launcher App';

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -21,12 +21,6 @@
  */
 
 /**
- * Global flag to enable/disable the Sentry logger
- * @type {boolean}
- */
-export const EnableSentry = false;
-
-/**
  * Set the application version string
  * @type {string}
  * @description
@@ -51,7 +45,7 @@ export const APP_VERSION = '1.7.0';
  * to QA or production.
  * @type {string}
  */
-export const APP_BUILD = '256';
+export const APP_BUILD = '257';
 
 /**
  * Development build stage designator


### PR DESCRIPTION
Correct text in the BP Launcher dropdown dialog for Windows to include Windows 11 and remove Window 7, which is no longer supported by Microsoft. 